### PR TITLE
fix: stack overflow when generic aliases pass same-named type parameters through

### DIFF
--- a/skills/install-anti-slop/assets/anti-slop/shared/dictionary-types.ts
+++ b/skills/install-anti-slop/assets/anti-slop/shared/dictionary-types.ts
@@ -158,13 +158,17 @@ function isEffectivelyEmptyInterface(
 function resolvedSubstitutionArgument(
 	type: ESTree.TSType,
 	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
 ): ESTree.TSType {
 	const unwrapped = unwrapTransparentType(type);
 	if (unwrapped.type !== "TSTypeReference") return type;
 	const name = typeReferenceName(unwrapped);
-	if (name === null) return type;
+	if (name === null || resolving.has(name)) return type;
 	const substitution = base.get(name);
-	return substitution === undefined ? type : resolvedSubstitutionArgument(substitution, base);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
 }
 
 function aliasSubstitution(

--- a/src/rules/no-unsafe-dictionary-type.test.ts
+++ b/src/rules/no-unsafe-dictionary-type.test.ts
@@ -30,6 +30,7 @@ tester.run("anti-slop/no-unsafe-dictionary-type", noUnsafeDictionaryTypeRule, {
 		"interface Escape {} interface Escape { readonly id: string } type A = Record<string, Escape>;",
 		"interface Escape { readonly id: string } interface Escape {} type A = Record<string, Escape>;",
 		"interface Owner { readonly id: string } type A = Record<string, object & Owner>;",
+		"type Wrap<T> = { readonly wrapped: T }; type Inner<T, U> = { readonly value: T } & Wrap<U>; type Outer<T, U> = Record<string, Inner<T, U>>; declare function f<T, U>(): Outer<T, U>;",
 	],
 	invalid: [
 		{ code: "type A = Record<string, unknown>;", errors: [error] },

--- a/src/shared/dictionary-types.ts
+++ b/src/shared/dictionary-types.ts
@@ -158,13 +158,17 @@ function isEffectivelyEmptyInterface(
 function resolvedSubstitutionArgument(
 	type: ESTree.TSType,
 	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
 ): ESTree.TSType {
 	const unwrapped = unwrapTransparentType(type);
 	if (unwrapped.type !== "TSTypeReference") return type;
 	const name = typeReferenceName(unwrapped);
-	if (name === null) return type;
+	if (name === null || resolving.has(name)) return type;
 	const substitution = base.get(name);
-	return substitution === undefined ? type : resolvedSubstitutionArgument(substitution, base);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
 }
 
 function aliasSubstitution(


### PR DESCRIPTION
## The bug

Linting this crashes with `RangeError: Maximum call stack size exceeded`:

```ts
type Wrap<T> = { readonly wrapped: T };
type Inner<T, U> = { readonly value: T } & Wrap<U>;
type Outer<T, U> = Record<string, Inner<T, U>>;

declare function f<T, U>(): Outer<T, U>;
```

It affects `no-known-value-widening`, `no-unsafe-dictionary-type`, and anything else that resolves aliases through `dictionary-types.ts`. We hit it on two real files while adopting the plugin in our monorepo — the trigger is just two generic aliases that pass values through to each other and happen to use the same type parameter names (`T`, `U`), which is how most TypeScript is written.

## Why it happens

When `aliasSubstitution` can't resolve an argument yet (e.g. `T` refers to the *caller's* own type parameter), it stores a self-referential entry in the substitution map: `T -> T`. That's harmless on its own. But the map is carried forward into the next alias's resolution, and when that alias also names a parameter `T`, `resolvedSubstitutionArgument` looks up `T`, gets `T` back, and recurses on the same input forever.

`resolvedSubstitutionArgument` is the only walker in `dictionary-types.ts` without a cycle guard — `unsafeDirectValue`, `dictionaryValueTypes`, and `classifyAliasBroadTarget` all already carry a `resolvingAliases` set for exactly this reason.

## The fix

Give it the same guard its siblings have: thread a set of names already being resolved, and stop when a name repeats. Already-resolved cases behave identically; only the infinite loop changes, returning the reference as-is (same as the existing `resolvingAliases.has(name)` bailouts).

The repro above is added as a valid case in `no-unsafe-dictionary-type.test.ts` — it crashes the suite without the fix and passes with it.

`pnpm check` passes (lint, test, typecheck, skill-assets sync via `pnpm sync:skill-assets`).

Thanks for the plugin — we ported all 10 rules into our monorepo and this was the only issue we hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)