### PR TITLE
Add no-self-licking and no-fraud rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ const options = {
 };
 ```
 
+### `no-fraud`
+
+```ts
+function saveOrder(order: Order) {
+  return { ok: true };
+}
+
+try {
+  await sync();
+} catch {
+  return { ok: true };
+}
+
+const supportEmail = "support@example.com";
+```
+
+Each one claims work that never happened. Test, mock, story, and fixture files are exempt.
+
 ### `no-known-value-widening`
 
 ```ts
@@ -108,6 +126,24 @@ if (typeof input === "string") {
   useName(input);
 }
 ```
+
+### `no-self-licking`
+
+```ts
+expect(total).toBe(total);
+
+it("saves", () => {
+  const save = vi.fn();
+  saveOrder(save);
+  expect(save).toHaveBeenCalledWith(order);
+});
+
+function getUser(id: UserId) {
+  return repository.getUser(id);
+}
+```
+
+None of these prove anything about the system: the assertion cannot fail, the test only checks its own double, and the function adds no behavior.
 
 ### `no-shape-in-symbol-names`
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ export default defineConfig({
   rules: {
     "anti-slop/no-chained-type-assertions": "error",
     "anti-slop/no-conditional-empty-object-spread": "error",
+    "anti-slop/no-fraud": "error",
     "anti-slop/no-known-value-widening": "error",
     "anti-slop/no-object-parameters": "error",
     "anti-slop/no-runtime-typeof": "error",
+    "anti-slop/no-self-licking": "error",
     "anti-slop/no-shape-in-symbol-names": "error",
     "anti-slop/no-unknown-parameters": "error",
     "anti-slop/no-unknown-type-aliases": "error",
@@ -54,9 +56,11 @@ The same `jsPlugins` entry and rules work under `lint` in a Vite+ config.
 
 - `no-chained-type-assertions` — rejects nested type assertions that fabricate evidence.
 - `no-conditional-empty-object-spread` — rejects conditional spreads that use `{}` to omit fields.
+- `no-fraud` — rejects implementations that claim work they never do: ignored inputs behind a hardcoded success, catch clauses that discard the error and report success, and placeholder data in production source. Test, mock, and fixture files are exempt, because fakes are honest there.
 - `no-known-value-widening` — rejects explicit broad target types that discard known value evidence.
 - `no-object-parameters` — rejects the broad `object` type on function inputs.
 - `no-runtime-typeof` — requires boundary parsing instead of ad hoc `typeof` narrowing.
+- `no-self-licking` — rejects constructs that only prove themselves: assertions that compare a value to itself, tests that assert only on their own doubles, and functions that forward their parameters unchanged.
 - `no-shape-in-symbol-names` — rejects `shape` in symbol names.
 - `no-unknown-parameters` — rejects `unknown` inputs except the explicit `cause` convention.
 - `no-unknown-type-aliases` — rejects aliases that merely conceal `unknown`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "check": "pnpm lint && pnpm test && pnpm typecheck && pnpm check:skill-assets",
     "lint": "oxlint src",
-    "test": "tsx src/rules/no-conditional-empty-object-spread.test.ts && tsx src/rules/no-unsafe-dictionary-type.test.ts && tsx src/rules/no-known-value-widening.test.ts && tsx src/rules/no-object-parameters.test.ts",
+    "test": "tsx src/rules/no-conditional-empty-object-spread.test.ts && tsx src/rules/no-unsafe-dictionary-type.test.ts && tsx src/rules/no-known-value-widening.test.ts && tsx src/rules/no-object-parameters.test.ts && tsx src/rules/no-self-licking.test.ts && tsx src/rules/no-fraud.test.ts",
     "typecheck": "tsc --noEmit",
     "sync:skill-assets": "node scripts/sync-skill-assets.mjs",
     "check:skill-assets": "node scripts/sync-skill-assets.mjs --check"

--- a/skills/install-anti-slop/SKILL.md
+++ b/skills/install-anti-slop/SKILL.md
@@ -46,9 +46,11 @@ Install the bundled Oxlint plugin into the current repository and integrate it w
    {
      "anti-slop/no-chained-type-assertions": "error",
      "anti-slop/no-conditional-empty-object-spread": "error",
+     "anti-slop/no-fraud": "error",
      "anti-slop/no-known-value-widening": "error",
      "anti-slop/no-object-parameters": "error",
      "anti-slop/no-runtime-typeof": "error",
+     "anti-slop/no-self-licking": "error",
      "anti-slop/no-shape-in-symbol-names": "error",
      "anti-slop/no-unknown-parameters": "error",
      "anti-slop/no-unknown-type-aliases": "error",

--- a/skills/install-anti-slop/assets/anti-slop/index.ts
+++ b/skills/install-anti-slop/assets/anti-slop/index.ts
@@ -2,9 +2,11 @@ import { definePlugin } from "@oxlint/plugins";
 
 import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
 import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noFraudRule } from "./rules/no-fraud.ts";
 import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
 import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
 import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noSelfLickingRule } from "./rules/no-self-licking.ts";
 import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
 import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
 import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
@@ -17,9 +19,11 @@ const antiSlopPlugin = definePlugin({
 	rules: {
 		"no-chained-type-assertions": noChainedTypeAssertionsRule,
 		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-fraud": noFraudRule,
 		"no-known-value-widening": noKnownValueWideningRule,
 		"no-object-parameters": noObjectParametersRule,
 		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-self-licking": noSelfLickingRule,
 		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
 		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
 		"no-unknown-parameters": noUnknownParametersRule,

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-fraud.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-fraud.ts
@@ -12,18 +12,10 @@ type CatchFrame = {
 	throws: number;
 };
 
-const PLACEHOLDER_VALUES = [
-	"changeme",
-	"example.com",
-	"example.net",
-	"example.org",
-	"foo@bar",
-	"jane doe",
-	"john doe",
-	"lorem ipsum",
-	"test@test",
-	"your-api-key",
-];
+const PLACEHOLDER_VALUE =
+	/changeme|example\.(?:com|net|org)|foo@bar|jane doe|john doe|lorem ipsum|test@test|your-api-key/iu;
+const QUOTED_TEXT = /^['"](.*)['"]$/su;
+const STRING_LITERAL = /^['"]/u;
 const FAILURE_KEYS = new Set(["cause", "error", "errors", "failed", "failure"]);
 const OUTCOME_KEYS = new Set(["ok", "success"]);
 const UNFINISHED_COMMENT = /\b(?:todo|fixme|unimplemented|not implemented)\b/iu;
@@ -73,9 +65,8 @@ function isLiteralValue(node: ESTree.Node): boolean {
 function propertyName(property: ESTree.ObjectProperty): string | null {
 	if (property.computed) return null;
 	if (property.key.type === "Identifier") return property.key.name;
-	return property.key.type === "Literal" && typeof property.key.value === "string"
-		? property.key.value
-		: null;
+	if (property.key.type !== "Literal") return null;
+	return QUOTED_TEXT.exec(property.key.raw ?? "")?.[1] ?? null;
 }
 
 /** An object literal is not a success claim when it names a failure or sets an outcome flag to false. */
@@ -161,10 +152,9 @@ export const noFraudRule = defineRule({
 		};
 
 		const checkPlaceholder = (node: ESTree.Node, text: string) => {
-			const lowercased = text.toLowerCase();
-			const value = PLACEHOLDER_VALUES.find((candidate) => lowercased.includes(candidate));
-			if (value === undefined) return;
-			context.report({ node, messageId: "placeholderData", data: { value } });
+			const found = PLACEHOLDER_VALUE.exec(text);
+			if (found === null) return;
+			context.report({ node, messageId: "placeholderData", data: { value: found[0] } });
 		};
 
 		return {
@@ -211,8 +201,9 @@ export const noFraudRule = defineRule({
 				context.report({ node, messageId: "errorSwallowedSuccess" });
 			},
 			Literal(node) {
-				if (typeof node.value !== "string") return;
-				checkPlaceholder(node, node.value);
+				const raw = node.raw ?? "";
+				if (!STRING_LITERAL.test(raw)) return;
+				checkPlaceholder(node, raw);
 			},
 			TemplateElement(node) {
 				checkPlaceholder(node, node.value.cooked ?? node.value.raw);

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-fraud.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-fraud.ts
@@ -1,0 +1,222 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type FunctionLike = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+type CatchFrame = {
+	readonly node: ESTree.CatchClause;
+	functionDepth: number;
+	returns: number;
+	fabricatedReturns: number;
+	throws: number;
+};
+
+const PLACEHOLDER_VALUES = [
+	"changeme",
+	"example.com",
+	"example.net",
+	"example.org",
+	"foo@bar",
+	"jane doe",
+	"john doe",
+	"lorem ipsum",
+	"test@test",
+	"your-api-key",
+];
+const FAILURE_KEYS = new Set(["cause", "error", "errors", "failed", "failure"]);
+const OUTCOME_KEYS = new Set(["ok", "success"]);
+const UNFINISHED_COMMENT = /\b(?:todo|fixme|unimplemented|not implemented)\b/iu;
+const TEST_FILE =
+	/(?:^|[/\\])(?:__tests__|__mocks__|fixtures|mocks|tests?)[/\\]|\.(?:test|spec|stories|mock|fixture)\.[cm]?[jt]sx?$/iu;
+
+function unwrapExpression(node: ESTree.Node): ESTree.Node {
+	let current = node;
+	for (;;) {
+		if (
+			current.type === "ParenthesizedExpression" ||
+			current.type === "TSAsExpression" ||
+			current.type === "TSSatisfiesExpression" ||
+			current.type === "TSNonNullExpression"
+		) {
+			current = current.expression;
+			continue;
+		}
+		return current;
+	}
+}
+
+function isLiteralValue(node: ESTree.Node): boolean {
+	const value = unwrapExpression(node);
+	switch (value.type) {
+		case "Literal":
+			return true;
+		case "TemplateLiteral":
+			return value.expressions.length === 0;
+		case "UnaryExpression":
+			return (value.operator === "-" || value.operator === "!") && isLiteralValue(value.argument);
+		case "ArrayExpression":
+			return value.elements.every(
+				(element) =>
+					element !== null && element.type !== "SpreadElement" && isLiteralValue(element),
+			);
+		case "ObjectExpression":
+			return value.properties.every(
+				(property) =>
+					property.type === "Property" && !property.computed && isLiteralValue(property.value),
+			);
+		default:
+			return false;
+	}
+}
+
+function propertyName(property: ESTree.ObjectProperty): string | null {
+	if (property.computed) return null;
+	if (property.key.type === "Identifier") return property.key.name;
+	return property.key.type === "Literal" && typeof property.key.value === "string"
+		? property.key.value
+		: null;
+}
+
+/** An object literal is not a success claim when it names a failure or sets an outcome flag to false. */
+function declaresFailure(value: ESTree.ObjectExpression): boolean {
+	return value.properties.some((property) => {
+		if (property.type !== "Property") return false;
+		const name = propertyName(property);
+		if (name === null) return false;
+		if (FAILURE_KEYS.has(name)) return true;
+		return (
+			OUTCOME_KEYS.has(name) && property.value.type === "Literal" && property.value.value === false
+		);
+	});
+}
+
+/** A hardcoded value that reports success: `true`, or an object or array built only from literals. */
+function isFabricatedSuccess(node: ESTree.Node): boolean {
+	const value = unwrapExpression(node);
+	if (value.type === "Literal") return value.value === true;
+	if (value.type === "ArrayExpression") return isLiteralValue(value);
+	return value.type === "ObjectExpression" && isLiteralValue(value) && !declaresFailure(value);
+}
+
+function finalReturnedExpression(node: FunctionLike): ESTree.Node | null {
+	const body = node.body;
+	if (body === null || body === undefined) return null;
+	if (body.type !== "BlockStatement") return body;
+	const last = body.body.at(-1);
+	return last?.type === "ReturnStatement" ? last.argument : null;
+}
+
+/** Reject implementations that claim work they never do: fake success, swallowed failures, and placeholder data. */
+export const noFraudRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow fraudulent implementations: functions that ignore their inputs and return hardcoded success, catch clauses that discard the error and report success, and placeholder data in production source.",
+		},
+		messages: {
+			fakeSuccess:
+				"This function accepts inputs it never reads and returns a hardcoded success, so callers cannot tell the work never happened. Implement the operation, or make the unfinished path fail loudly.",
+			errorSwallowedSuccess:
+				"This catch clause discards the error and reports success, hiding the failure from callers. Return a failure result, or rethrow with the original error as `cause`.",
+			placeholderData:
+				'Placeholder value "{{value}}" ships in production source and misrepresents real data. Read the value from configuration, or take it from the caller.',
+		},
+	},
+	create(context) {
+		if (TEST_FILE.test(context.filename)) return {};
+
+		const frames: CatchFrame[] = [];
+
+		const ignoresParameters = (node: FunctionLike): boolean => {
+			const parameters = context.sourceCode
+				.getDeclaredVariables(node)
+				.filter((variable) => variable.defs.some((definition) => definition.type === "Parameter"))
+				.filter((variable) => !variable.name.startsWith("_"));
+			return (
+				parameters.length > 0 && parameters.every((variable) => variable.references.length === 0)
+			);
+		};
+
+		const hasUnfinishedComment = (node: FunctionLike): boolean =>
+			context.sourceCode
+				.getCommentsInside(node)
+				.some((comment) => UNFINISHED_COMMENT.test(comment.value));
+
+		const checkFunction = (node: FunctionLike) => {
+			const frame = frames.at(-1);
+			if (frame !== undefined) frame.functionDepth += 1;
+
+			if (node.params.length === 0) return;
+			const returned = finalReturnedExpression(node);
+			if (returned === null || !isFabricatedSuccess(returned)) return;
+			if (!ignoresParameters(node) && !hasUnfinishedComment(node)) return;
+			context.report({ node: returned, messageId: "fakeSuccess" });
+		};
+
+		const exitFunction = () => {
+			const frame = frames.at(-1);
+			if (frame !== undefined) frame.functionDepth -= 1;
+		};
+
+		const checkPlaceholder = (node: ESTree.Node, text: string) => {
+			const lowercased = text.toLowerCase();
+			const value = PLACEHOLDER_VALUES.find((candidate) => lowercased.includes(candidate));
+			if (value === undefined) return;
+			context.report({ node, messageId: "placeholderData", data: { value } });
+		};
+
+		return {
+			ArrowFunctionExpression: checkFunction,
+			FunctionDeclaration: checkFunction,
+			FunctionExpression: checkFunction,
+			"ArrowFunctionExpression:exit": exitFunction,
+			"FunctionDeclaration:exit": exitFunction,
+			"FunctionExpression:exit": exitFunction,
+			CatchClause(node) {
+				frames.push({ node, functionDepth: 0, returns: 0, fabricatedReturns: 0, throws: 0 });
+			},
+			ReturnStatement(node) {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.functionDepth > 0) return;
+				frame.returns += 1;
+				if (node.argument !== null && isFabricatedSuccess(node.argument)) {
+					frame.fabricatedReturns += 1;
+				}
+			},
+			ThrowStatement() {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.functionDepth > 0) return;
+				frame.throws += 1;
+			},
+			"CatchClause:exit"(node) {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.node !== node) return;
+				frames.pop();
+
+				const usesError =
+					node.param !== null &&
+					context.sourceCode
+						.getDeclaredVariables(node)
+						.some((variable) => variable.references.length > 0);
+				if (
+					usesError ||
+					frame.throws > 0 ||
+					frame.returns === 0 ||
+					frame.returns !== frame.fabricatedReturns
+				) {
+					return;
+				}
+				context.report({ node, messageId: "errorSwallowedSuccess" });
+			},
+			Literal(node) {
+				if (typeof node.value !== "string") return;
+				checkPlaceholder(node, node.value);
+			},
+			TemplateElement(node) {
+				checkPlaceholder(node, node.value.cooked ?? node.value.raw);
+			},
+		};
+	},
+});

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-self-licking.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-self-licking.ts
@@ -1,0 +1,222 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type FunctionLike = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+type Assertion = {
+	readonly subject: ESTree.Node | null;
+	readonly expected: ESTree.Node | null;
+};
+
+type TestFrame = {
+	readonly node: ESTree.CallExpression;
+	assertions: number;
+	mockOnly: boolean;
+};
+
+const TEST_CALLEES = new Set(["it", "test"]);
+const MOCK_NAMESPACES = new Set(["jest", "mock", "sinon", "td", "vi"]);
+const MOCK_FACTORIES = new Set(["fn", "mock", "spy", "spyOn", "stub"]);
+const EQUALITY_ASSERTIONS = new Set([
+	"deepEqual",
+	"deepStrictEqual",
+	"equal",
+	"notDeepEqual",
+	"notDeepStrictEqual",
+	"notEqual",
+	"notStrictEqual",
+	"strictEqual",
+]);
+const COMPARISON_OPERATORS = new Set(["!=", "!==", "<", "<=", "==", "===", ">", ">="]);
+
+function unwrapExpression(node: ESTree.Node): ESTree.Node {
+	let current = node;
+	for (;;) {
+		if (
+			current.type === "ParenthesizedExpression" ||
+			current.type === "TSAsExpression" ||
+			current.type === "TSSatisfiesExpression" ||
+			current.type === "TSNonNullExpression"
+		) {
+			current = current.expression;
+			continue;
+		}
+		if (current.type === "AwaitExpression") {
+			current = current.argument;
+			continue;
+		}
+		return current;
+	}
+}
+
+/** Walk member and call chains down to the identifier or call the chain is built on. */
+function chainRoot(node: ESTree.Node): ESTree.Node {
+	let current = unwrapExpression(node);
+	for (;;) {
+		if (current.type === "MemberExpression") {
+			current = unwrapExpression(current.object);
+			continue;
+		}
+		if (current.type === "CallExpression" && current.callee.type !== "Identifier") {
+			current = unwrapExpression(current.callee);
+			continue;
+		}
+		return current;
+	}
+}
+
+function argumentAt(node: ESTree.CallExpression, index: number): ESTree.Node | null {
+	const argument = node.arguments[index];
+	return argument === undefined || argument.type === "SpreadElement" ? null : argument;
+}
+
+function assertion(node: ESTree.CallExpression): Assertion | null {
+	if (node.callee.type === "Identifier") {
+		if (node.callee.name === "assert") return { subject: argumentAt(node, 0), expected: null };
+		if (!EQUALITY_ASSERTIONS.has(node.callee.name)) return null;
+		return { subject: argumentAt(node, 0), expected: argumentAt(node, 1) };
+	}
+	if (node.callee.type !== "MemberExpression") return null;
+
+	const root = chainRoot(node.callee);
+	if (root.type === "Identifier") {
+		return root.name === "assert"
+			? { subject: argumentAt(node, 0), expected: argumentAt(node, 1) }
+			: null;
+	}
+	if (root.type !== "CallExpression" || root.callee.type !== "Identifier") return null;
+	return root.callee.name === "expect"
+		? { subject: argumentAt(root, 0), expected: argumentAt(node, 0) }
+		: null;
+}
+
+function isTestCall(node: ESTree.CallExpression): boolean {
+	const root = chainRoot(node.callee);
+	return root.type === "Identifier" && TEST_CALLEES.has(root.name);
+}
+
+function isMockFactoryCall(node: ESTree.Node): boolean {
+	const call = unwrapExpression(node);
+	if (call.type !== "CallExpression" || call.callee.type !== "MemberExpression") return false;
+	const { object, property } = call.callee;
+	if (property.type !== "Identifier" || !MOCK_FACTORIES.has(property.name)) return false;
+	const namespace = chainRoot(object);
+	return namespace.type === "Identifier" && MOCK_NAMESPACES.has(namespace.name);
+}
+
+function parameterNames(node: FunctionLike): readonly string[] | null {
+	const names: string[] = [];
+	for (const parameter of node.params) {
+		if (parameter.type !== "Identifier") return null;
+		names.push(parameter.name);
+	}
+	return names.length === 0 ? null : names;
+}
+
+function returnedExpression(node: FunctionLike): ESTree.Node | null {
+	const body = node.body;
+	if (body === null || body === undefined) return null;
+	if (body.type !== "BlockStatement") return body;
+	if (body.body.length !== 1) return null;
+	const [statement] = body.body;
+	return statement?.type === "ReturnStatement" ? statement.argument : null;
+}
+
+function isPassThrough(node: FunctionLike): boolean {
+	const names = parameterNames(node);
+	const returned = returnedExpression(node);
+	if (names === null || returned === null) return false;
+
+	if (returned.type === "Identifier") return names.includes(returned.name);
+	if (returned.type !== "CallExpression" || returned.arguments.length !== names.length) {
+		return false;
+	}
+	return returned.arguments.every(
+		(argument, index) => argument.type === "Identifier" && argument.name === names[index],
+	);
+}
+
+/** Reject constructs that only prove themselves: self-comparing assertions, mock-only tests, and pass-through functions. */
+export const noSelfLickingRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow self-licking constructs: assertions that compare a value to itself, tests that only assert on their own doubles, and functions that forward their parameters unchanged.",
+		},
+		messages: {
+			tautologicalAssertion:
+				"This assertion compares a value to itself, so it passes no matter what the code under test does. Assert the value the implementation is expected to produce.",
+			mockOnlyAssertion:
+				"This test only asserts on doubles it created, so it proves the mock rather than the system. Assert an observable result of the code under test.",
+			passThroughWrapper:
+				"This function forwards its parameters unchanged and adds no behavior, so it hides the real call site without adding evidence. Call the underlying operation directly or give this function real work.",
+		},
+	},
+	create(context) {
+		const mockNames = new Set<string>();
+		const frames: TestFrame[] = [];
+
+		const normalizedText = (node: ESTree.Node): string =>
+			context.sourceCode.getText(node).replaceAll(/\s+/gu, "");
+
+		const isSelfComparison = ({ subject, expected }: Assertion): boolean => {
+			if (subject === null) return false;
+			if (expected !== null && normalizedText(subject) === normalizedText(expected)) return true;
+
+			const inner = unwrapExpression(subject);
+			return (
+				inner.type === "BinaryExpression" &&
+				COMPARISON_OPERATORS.has(inner.operator) &&
+				inner.left.type !== "PrivateIdentifier" &&
+				normalizedText(inner.left) === normalizedText(inner.right)
+			);
+		};
+
+		const recordAssertion = (node: ESTree.CallExpression, { subject }: Assertion) => {
+			const frame = frames.at(-1);
+			if (frame === undefined || frame.node === node) return;
+			frame.assertions += 1;
+			if (subject === null) {
+				frame.mockOnly = false;
+				return;
+			}
+			const root = chainRoot(subject);
+			if (root.type !== "Identifier" || !mockNames.has(root.name)) frame.mockOnly = false;
+		};
+
+		const checkFunction = (node: FunctionLike) => {
+			if (!isPassThrough(node)) return;
+			context.report({ node, messageId: "passThroughWrapper" });
+		};
+
+		return {
+			VariableDeclarator(node) {
+				if (node.id.type !== "Identifier" || node.init === null) return;
+				if (isMockFactoryCall(node.init)) mockNames.add(node.id.name);
+			},
+			CallExpression(node) {
+				if (isTestCall(node)) frames.push({ node, assertions: 0, mockOnly: true });
+
+				const found = assertion(node);
+				if (found === null) return;
+				if (isSelfComparison(found)) {
+					context.report({ node, messageId: "tautologicalAssertion" });
+				}
+				recordAssertion(node, found);
+			},
+			"CallExpression:exit"(node) {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.node !== node) return;
+				frames.pop();
+				if (frame.assertions > 0 && frame.mockOnly) {
+					context.report({ node: node.callee, messageId: "mockOnlyAssertion" });
+				}
+			},
+			ArrowFunctionExpression: checkFunction,
+			FunctionDeclaration: checkFunction,
+			FunctionExpression: checkFunction,
+		};
+	},
+});

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-self-licking.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-self-licking.ts
@@ -123,7 +123,15 @@ function returnedExpression(node: FunctionLike): ESTree.Node | null {
 	return statement?.type === "ReturnStatement" ? statement.argument : null;
 }
 
+/** A function passed straight to a call is call-site syntax, not an indirection in the API surface. */
+function isInlineCallback(node: FunctionLike): boolean {
+	const parent = node.parent;
+	if (parent.type !== "CallExpression" && parent.type !== "NewExpression") return false;
+	return parent.callee !== node;
+}
+
 function isPassThrough(node: FunctionLike): boolean {
+	if (isInlineCallback(node)) return false;
 	const names = parameterNames(node);
 	const returned = returnedExpression(node);
 	if (names === null || returned === null) return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,11 @@ import { definePlugin } from "@oxlint/plugins";
 
 import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
 import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noFraudRule } from "./rules/no-fraud.ts";
 import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
 import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
 import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noSelfLickingRule } from "./rules/no-self-licking.ts";
 import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
 import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
 import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
@@ -17,9 +19,11 @@ const antiSlopPlugin = definePlugin({
 	rules: {
 		"no-chained-type-assertions": noChainedTypeAssertionsRule,
 		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-fraud": noFraudRule,
 		"no-known-value-widening": noKnownValueWideningRule,
 		"no-object-parameters": noObjectParametersRule,
 		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-self-licking": noSelfLickingRule,
 		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
 		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
 		"no-unknown-parameters": noUnknownParametersRule,

--- a/src/rules/no-fraud.test.ts
+++ b/src/rules/no-fraud.test.ts
@@ -1,0 +1,43 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noFraudRule } from "./no-fraud.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const fakeSuccess = { messageId: "fakeSuccess" };
+const errorSwallowedSuccess = { messageId: "errorSwallowedSuccess" };
+const placeholderData = { messageId: "placeholderData" };
+
+tester.run("anti-slop/no-fraud", noFraudRule, {
+	valid: [
+		"function saveOrder(order: Order) { return repository.save(order); }",
+		"function isEnabled(flag: Flag) { return flag.enabled; }",
+		"function isEnabled(_flag: Flag) { return true; }",
+		"function defaults() { return { retries: 3 }; }",
+		"function run(input: string) { try { work(input); } catch (cause) { return { ok: false, cause }; } }",
+		"function run(input: string) { try { work(input); } catch (cause) { throw new Error('sync failed', { cause }); } }",
+		"function run(input: string) { try { work(input); } catch { return { ok: false }; } }",
+		"const contact = process.env.SUPPORT_EMAIL;",
+		{ code: 'const user = { name: "John Doe" };', filename: "user.test.ts" },
+		{ code: 'const user = { name: "John Doe" };', filename: "fixtures/user.ts" },
+	],
+	invalid: [
+		{ code: "function saveOrder(order: Order) { return { ok: true }; }", errors: [fakeSuccess] },
+		{ code: "function validate(input: Input) { return true; }", errors: [fakeSuccess] },
+		{ code: "const listUsers = (filter: Filter) => [{ id: '1' }];", errors: [fakeSuccess] },
+		{
+			code: "function validate(input: Input) { report(input); /* TODO: implement */ return true; }",
+			errors: [fakeSuccess],
+		},
+		{
+			code: "function run(input: string) { try { work(input); } catch (cause) { return true; } }",
+			errors: [errorSwallowedSuccess],
+		},
+		{
+			code: "async function sync(id: string) { try { await push(id); } catch { return { ok: true }; } }",
+			errors: [errorSwallowedSuccess],
+		},
+		{ code: 'const contact = "support@example.com";', errors: [placeholderData] },
+		{ code: "const message = `Lorem ipsum dolor sit amet`;", errors: [placeholderData] },
+		{ code: 'const user = { name: "John Doe" };', errors: [placeholderData] },
+	],
+});

--- a/src/rules/no-fraud.ts
+++ b/src/rules/no-fraud.ts
@@ -12,18 +12,10 @@ type CatchFrame = {
 	throws: number;
 };
 
-const PLACEHOLDER_VALUES = [
-	"changeme",
-	"example.com",
-	"example.net",
-	"example.org",
-	"foo@bar",
-	"jane doe",
-	"john doe",
-	"lorem ipsum",
-	"test@test",
-	"your-api-key",
-];
+const PLACEHOLDER_VALUE =
+	/changeme|example\.(?:com|net|org)|foo@bar|jane doe|john doe|lorem ipsum|test@test|your-api-key/iu;
+const QUOTED_TEXT = /^['"](.*)['"]$/su;
+const STRING_LITERAL = /^['"]/u;
 const FAILURE_KEYS = new Set(["cause", "error", "errors", "failed", "failure"]);
 const OUTCOME_KEYS = new Set(["ok", "success"]);
 const UNFINISHED_COMMENT = /\b(?:todo|fixme|unimplemented|not implemented)\b/iu;
@@ -73,9 +65,8 @@ function isLiteralValue(node: ESTree.Node): boolean {
 function propertyName(property: ESTree.ObjectProperty): string | null {
 	if (property.computed) return null;
 	if (property.key.type === "Identifier") return property.key.name;
-	return property.key.type === "Literal" && typeof property.key.value === "string"
-		? property.key.value
-		: null;
+	if (property.key.type !== "Literal") return null;
+	return QUOTED_TEXT.exec(property.key.raw ?? "")?.[1] ?? null;
 }
 
 /** An object literal is not a success claim when it names a failure or sets an outcome flag to false. */
@@ -161,10 +152,9 @@ export const noFraudRule = defineRule({
 		};
 
 		const checkPlaceholder = (node: ESTree.Node, text: string) => {
-			const lowercased = text.toLowerCase();
-			const value = PLACEHOLDER_VALUES.find((candidate) => lowercased.includes(candidate));
-			if (value === undefined) return;
-			context.report({ node, messageId: "placeholderData", data: { value } });
+			const found = PLACEHOLDER_VALUE.exec(text);
+			if (found === null) return;
+			context.report({ node, messageId: "placeholderData", data: { value: found[0] } });
 		};
 
 		return {
@@ -211,8 +201,9 @@ export const noFraudRule = defineRule({
 				context.report({ node, messageId: "errorSwallowedSuccess" });
 			},
 			Literal(node) {
-				if (typeof node.value !== "string") return;
-				checkPlaceholder(node, node.value);
+				const raw = node.raw ?? "";
+				if (!STRING_LITERAL.test(raw)) return;
+				checkPlaceholder(node, raw);
 			},
 			TemplateElement(node) {
 				checkPlaceholder(node, node.value.cooked ?? node.value.raw);

--- a/src/rules/no-fraud.ts
+++ b/src/rules/no-fraud.ts
@@ -1,0 +1,222 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type FunctionLike = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+type CatchFrame = {
+	readonly node: ESTree.CatchClause;
+	functionDepth: number;
+	returns: number;
+	fabricatedReturns: number;
+	throws: number;
+};
+
+const PLACEHOLDER_VALUES = [
+	"changeme",
+	"example.com",
+	"example.net",
+	"example.org",
+	"foo@bar",
+	"jane doe",
+	"john doe",
+	"lorem ipsum",
+	"test@test",
+	"your-api-key",
+];
+const FAILURE_KEYS = new Set(["cause", "error", "errors", "failed", "failure"]);
+const OUTCOME_KEYS = new Set(["ok", "success"]);
+const UNFINISHED_COMMENT = /\b(?:todo|fixme|unimplemented|not implemented)\b/iu;
+const TEST_FILE =
+	/(?:^|[/\\])(?:__tests__|__mocks__|fixtures|mocks|tests?)[/\\]|\.(?:test|spec|stories|mock|fixture)\.[cm]?[jt]sx?$/iu;
+
+function unwrapExpression(node: ESTree.Node): ESTree.Node {
+	let current = node;
+	for (;;) {
+		if (
+			current.type === "ParenthesizedExpression" ||
+			current.type === "TSAsExpression" ||
+			current.type === "TSSatisfiesExpression" ||
+			current.type === "TSNonNullExpression"
+		) {
+			current = current.expression;
+			continue;
+		}
+		return current;
+	}
+}
+
+function isLiteralValue(node: ESTree.Node): boolean {
+	const value = unwrapExpression(node);
+	switch (value.type) {
+		case "Literal":
+			return true;
+		case "TemplateLiteral":
+			return value.expressions.length === 0;
+		case "UnaryExpression":
+			return (value.operator === "-" || value.operator === "!") && isLiteralValue(value.argument);
+		case "ArrayExpression":
+			return value.elements.every(
+				(element) =>
+					element !== null && element.type !== "SpreadElement" && isLiteralValue(element),
+			);
+		case "ObjectExpression":
+			return value.properties.every(
+				(property) =>
+					property.type === "Property" && !property.computed && isLiteralValue(property.value),
+			);
+		default:
+			return false;
+	}
+}
+
+function propertyName(property: ESTree.ObjectProperty): string | null {
+	if (property.computed) return null;
+	if (property.key.type === "Identifier") return property.key.name;
+	return property.key.type === "Literal" && typeof property.key.value === "string"
+		? property.key.value
+		: null;
+}
+
+/** An object literal is not a success claim when it names a failure or sets an outcome flag to false. */
+function declaresFailure(value: ESTree.ObjectExpression): boolean {
+	return value.properties.some((property) => {
+		if (property.type !== "Property") return false;
+		const name = propertyName(property);
+		if (name === null) return false;
+		if (FAILURE_KEYS.has(name)) return true;
+		return (
+			OUTCOME_KEYS.has(name) && property.value.type === "Literal" && property.value.value === false
+		);
+	});
+}
+
+/** A hardcoded value that reports success: `true`, or an object or array built only from literals. */
+function isFabricatedSuccess(node: ESTree.Node): boolean {
+	const value = unwrapExpression(node);
+	if (value.type === "Literal") return value.value === true;
+	if (value.type === "ArrayExpression") return isLiteralValue(value);
+	return value.type === "ObjectExpression" && isLiteralValue(value) && !declaresFailure(value);
+}
+
+function finalReturnedExpression(node: FunctionLike): ESTree.Node | null {
+	const body = node.body;
+	if (body === null || body === undefined) return null;
+	if (body.type !== "BlockStatement") return body;
+	const last = body.body.at(-1);
+	return last?.type === "ReturnStatement" ? last.argument : null;
+}
+
+/** Reject implementations that claim work they never do: fake success, swallowed failures, and placeholder data. */
+export const noFraudRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow fraudulent implementations: functions that ignore their inputs and return hardcoded success, catch clauses that discard the error and report success, and placeholder data in production source.",
+		},
+		messages: {
+			fakeSuccess:
+				"This function accepts inputs it never reads and returns a hardcoded success, so callers cannot tell the work never happened. Implement the operation, or make the unfinished path fail loudly.",
+			errorSwallowedSuccess:
+				"This catch clause discards the error and reports success, hiding the failure from callers. Return a failure result, or rethrow with the original error as `cause`.",
+			placeholderData:
+				'Placeholder value "{{value}}" ships in production source and misrepresents real data. Read the value from configuration, or take it from the caller.',
+		},
+	},
+	create(context) {
+		if (TEST_FILE.test(context.filename)) return {};
+
+		const frames: CatchFrame[] = [];
+
+		const ignoresParameters = (node: FunctionLike): boolean => {
+			const parameters = context.sourceCode
+				.getDeclaredVariables(node)
+				.filter((variable) => variable.defs.some((definition) => definition.type === "Parameter"))
+				.filter((variable) => !variable.name.startsWith("_"));
+			return (
+				parameters.length > 0 && parameters.every((variable) => variable.references.length === 0)
+			);
+		};
+
+		const hasUnfinishedComment = (node: FunctionLike): boolean =>
+			context.sourceCode
+				.getCommentsInside(node)
+				.some((comment) => UNFINISHED_COMMENT.test(comment.value));
+
+		const checkFunction = (node: FunctionLike) => {
+			const frame = frames.at(-1);
+			if (frame !== undefined) frame.functionDepth += 1;
+
+			if (node.params.length === 0) return;
+			const returned = finalReturnedExpression(node);
+			if (returned === null || !isFabricatedSuccess(returned)) return;
+			if (!ignoresParameters(node) && !hasUnfinishedComment(node)) return;
+			context.report({ node: returned, messageId: "fakeSuccess" });
+		};
+
+		const exitFunction = () => {
+			const frame = frames.at(-1);
+			if (frame !== undefined) frame.functionDepth -= 1;
+		};
+
+		const checkPlaceholder = (node: ESTree.Node, text: string) => {
+			const lowercased = text.toLowerCase();
+			const value = PLACEHOLDER_VALUES.find((candidate) => lowercased.includes(candidate));
+			if (value === undefined) return;
+			context.report({ node, messageId: "placeholderData", data: { value } });
+		};
+
+		return {
+			ArrowFunctionExpression: checkFunction,
+			FunctionDeclaration: checkFunction,
+			FunctionExpression: checkFunction,
+			"ArrowFunctionExpression:exit": exitFunction,
+			"FunctionDeclaration:exit": exitFunction,
+			"FunctionExpression:exit": exitFunction,
+			CatchClause(node) {
+				frames.push({ node, functionDepth: 0, returns: 0, fabricatedReturns: 0, throws: 0 });
+			},
+			ReturnStatement(node) {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.functionDepth > 0) return;
+				frame.returns += 1;
+				if (node.argument !== null && isFabricatedSuccess(node.argument)) {
+					frame.fabricatedReturns += 1;
+				}
+			},
+			ThrowStatement() {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.functionDepth > 0) return;
+				frame.throws += 1;
+			},
+			"CatchClause:exit"(node) {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.node !== node) return;
+				frames.pop();
+
+				const usesError =
+					node.param !== null &&
+					context.sourceCode
+						.getDeclaredVariables(node)
+						.some((variable) => variable.references.length > 0);
+				if (
+					usesError ||
+					frame.throws > 0 ||
+					frame.returns === 0 ||
+					frame.returns !== frame.fabricatedReturns
+				) {
+					return;
+				}
+				context.report({ node, messageId: "errorSwallowedSuccess" });
+			},
+			Literal(node) {
+				if (typeof node.value !== "string") return;
+				checkPlaceholder(node, node.value);
+			},
+			TemplateElement(node) {
+				checkPlaceholder(node, node.value.cooked ?? node.value.raw);
+			},
+		};
+	},
+});

--- a/src/rules/no-self-licking.test.ts
+++ b/src/rules/no-self-licking.test.ts
@@ -22,6 +22,8 @@ tester.run("anti-slop/no-self-licking", noSelfLickingRule, {
 		"function getUser(id: UserId, includeDeleted: boolean) { return repository.getUser(id); }",
 		"const forward = (...args: readonly string[]) => join(...args);",
 		"const now = () => clock.now();",
+		"const match = candidates.find((candidate) => text.includes(candidate));",
+		"const names = users.map((user) => format(user));",
 	],
 	invalid: [
 		{ code: "expect(true).toBe(true);", errors: [tautological] },

--- a/src/rules/no-self-licking.test.ts
+++ b/src/rules/no-self-licking.test.ts
@@ -1,0 +1,55 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noSelfLickingRule } from "./no-self-licking.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const tautological = { messageId: "tautologicalAssertion" };
+const mockOnly = { messageId: "mockOnlyAssertion" };
+const passThrough = { messageId: "passThroughWrapper" };
+
+tester.run("anti-slop/no-self-licking", noSelfLickingRule, {
+	valid: [
+		"expect(total).toBe(42);",
+		"expect(user.id).toEqual(other.id);",
+		"assert.strictEqual(parsed.name, 'ada');",
+		"assert(total > 0);",
+		"it('saves', () => { const save = vi.fn(); saveOrder(save); expect(store.rows).toEqual([order]); });",
+		"it('saves', () => { const save = vi.fn(); saveOrder(save); expect(save).toHaveBeenCalledWith(order); expect(store.rows).toEqual([order]); });",
+		"it('saves', () => { const save = vi.fn(); saveOrder(save); });",
+		"it('parses', () => { const parsed = parse(input); expect(parsed.name).toBe('ada'); });",
+		"function getUser(id: UserId) { const row = repository.getUser(id); return parseUser(row); }",
+		"function getUser(id: UserId) { return repository.getUser(id.value); }",
+		"function getUser(id: UserId, includeDeleted: boolean) { return repository.getUser(id); }",
+		"const forward = (...args: readonly string[]) => join(...args);",
+		"const now = () => clock.now();",
+	],
+	invalid: [
+		{ code: "expect(true).toBe(true);", errors: [tautological] },
+		{ code: "expect(total).toBe(total);", errors: [tautological] },
+		{ code: "expect(user.id).toEqual(user.id);", errors: [tautological] },
+		{ code: "expect(total).not.toBe(total);", errors: [tautological] },
+		{ code: "assert.strictEqual(config, config);", errors: [tautological] },
+		{ code: "strictEqual(config, config);", errors: [tautological] },
+		{ code: "assert(total === total);", errors: [tautological] },
+		{ code: "expect(total === total).toBe(true);", errors: [tautological] },
+		{
+			code: "it('saves', () => { const save = vi.fn(); saveOrder(save); expect(save).toHaveBeenCalledWith(order); });",
+			errors: [mockOnly],
+		},
+		{
+			code: "test('saves', () => { const save = jest.fn(); saveOrder(save); expect(save).toHaveBeenCalled(); expect(save.mock.calls).toHaveLength(1); });",
+			errors: [mockOnly],
+		},
+		{
+			code: "it('reads', () => { const read = sinon.stub(); readOrder(read); assert.strictEqual(read.callCount, 1); });",
+			errors: [mockOnly],
+		},
+		{ code: "function getUser(id: UserId) { return repository.getUser(id); }", errors: [passThrough] },
+		{ code: "const toUser = (user: User): User => user;", errors: [passThrough] },
+		{ code: "const getUser = (id: UserId) => repository.getUser(id);", errors: [passThrough] },
+		{
+			code: "class Store { save(order: Order) { return this.repository.save(order); } }",
+			errors: [passThrough],
+		},
+	],
+});

--- a/src/rules/no-self-licking.ts
+++ b/src/rules/no-self-licking.ts
@@ -1,0 +1,222 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type FunctionLike = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+type Assertion = {
+	readonly subject: ESTree.Node | null;
+	readonly expected: ESTree.Node | null;
+};
+
+type TestFrame = {
+	readonly node: ESTree.CallExpression;
+	assertions: number;
+	mockOnly: boolean;
+};
+
+const TEST_CALLEES = new Set(["it", "test"]);
+const MOCK_NAMESPACES = new Set(["jest", "mock", "sinon", "td", "vi"]);
+const MOCK_FACTORIES = new Set(["fn", "mock", "spy", "spyOn", "stub"]);
+const EQUALITY_ASSERTIONS = new Set([
+	"deepEqual",
+	"deepStrictEqual",
+	"equal",
+	"notDeepEqual",
+	"notDeepStrictEqual",
+	"notEqual",
+	"notStrictEqual",
+	"strictEqual",
+]);
+const COMPARISON_OPERATORS = new Set(["!=", "!==", "<", "<=", "==", "===", ">", ">="]);
+
+function unwrapExpression(node: ESTree.Node): ESTree.Node {
+	let current = node;
+	for (;;) {
+		if (
+			current.type === "ParenthesizedExpression" ||
+			current.type === "TSAsExpression" ||
+			current.type === "TSSatisfiesExpression" ||
+			current.type === "TSNonNullExpression"
+		) {
+			current = current.expression;
+			continue;
+		}
+		if (current.type === "AwaitExpression") {
+			current = current.argument;
+			continue;
+		}
+		return current;
+	}
+}
+
+/** Walk member and call chains down to the identifier or call the chain is built on. */
+function chainRoot(node: ESTree.Node): ESTree.Node {
+	let current = unwrapExpression(node);
+	for (;;) {
+		if (current.type === "MemberExpression") {
+			current = unwrapExpression(current.object);
+			continue;
+		}
+		if (current.type === "CallExpression" && current.callee.type !== "Identifier") {
+			current = unwrapExpression(current.callee);
+			continue;
+		}
+		return current;
+	}
+}
+
+function argumentAt(node: ESTree.CallExpression, index: number): ESTree.Node | null {
+	const argument = node.arguments[index];
+	return argument === undefined || argument.type === "SpreadElement" ? null : argument;
+}
+
+function assertion(node: ESTree.CallExpression): Assertion | null {
+	if (node.callee.type === "Identifier") {
+		if (node.callee.name === "assert") return { subject: argumentAt(node, 0), expected: null };
+		if (!EQUALITY_ASSERTIONS.has(node.callee.name)) return null;
+		return { subject: argumentAt(node, 0), expected: argumentAt(node, 1) };
+	}
+	if (node.callee.type !== "MemberExpression") return null;
+
+	const root = chainRoot(node.callee);
+	if (root.type === "Identifier") {
+		return root.name === "assert"
+			? { subject: argumentAt(node, 0), expected: argumentAt(node, 1) }
+			: null;
+	}
+	if (root.type !== "CallExpression" || root.callee.type !== "Identifier") return null;
+	return root.callee.name === "expect"
+		? { subject: argumentAt(root, 0), expected: argumentAt(node, 0) }
+		: null;
+}
+
+function isTestCall(node: ESTree.CallExpression): boolean {
+	const root = chainRoot(node.callee);
+	return root.type === "Identifier" && TEST_CALLEES.has(root.name);
+}
+
+function isMockFactoryCall(node: ESTree.Node): boolean {
+	const call = unwrapExpression(node);
+	if (call.type !== "CallExpression" || call.callee.type !== "MemberExpression") return false;
+	const { object, property } = call.callee;
+	if (property.type !== "Identifier" || !MOCK_FACTORIES.has(property.name)) return false;
+	const namespace = chainRoot(object);
+	return namespace.type === "Identifier" && MOCK_NAMESPACES.has(namespace.name);
+}
+
+function parameterNames(node: FunctionLike): readonly string[] | null {
+	const names: string[] = [];
+	for (const parameter of node.params) {
+		if (parameter.type !== "Identifier") return null;
+		names.push(parameter.name);
+	}
+	return names.length === 0 ? null : names;
+}
+
+function returnedExpression(node: FunctionLike): ESTree.Node | null {
+	const body = node.body;
+	if (body === null || body === undefined) return null;
+	if (body.type !== "BlockStatement") return body;
+	if (body.body.length !== 1) return null;
+	const [statement] = body.body;
+	return statement?.type === "ReturnStatement" ? statement.argument : null;
+}
+
+function isPassThrough(node: FunctionLike): boolean {
+	const names = parameterNames(node);
+	const returned = returnedExpression(node);
+	if (names === null || returned === null) return false;
+
+	if (returned.type === "Identifier") return names.includes(returned.name);
+	if (returned.type !== "CallExpression" || returned.arguments.length !== names.length) {
+		return false;
+	}
+	return returned.arguments.every(
+		(argument, index) => argument.type === "Identifier" && argument.name === names[index],
+	);
+}
+
+/** Reject constructs that only prove themselves: self-comparing assertions, mock-only tests, and pass-through functions. */
+export const noSelfLickingRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow self-licking constructs: assertions that compare a value to itself, tests that only assert on their own doubles, and functions that forward their parameters unchanged.",
+		},
+		messages: {
+			tautologicalAssertion:
+				"This assertion compares a value to itself, so it passes no matter what the code under test does. Assert the value the implementation is expected to produce.",
+			mockOnlyAssertion:
+				"This test only asserts on doubles it created, so it proves the mock rather than the system. Assert an observable result of the code under test.",
+			passThroughWrapper:
+				"This function forwards its parameters unchanged and adds no behavior, so it hides the real call site without adding evidence. Call the underlying operation directly or give this function real work.",
+		},
+	},
+	create(context) {
+		const mockNames = new Set<string>();
+		const frames: TestFrame[] = [];
+
+		const normalizedText = (node: ESTree.Node): string =>
+			context.sourceCode.getText(node).replaceAll(/\s+/gu, "");
+
+		const isSelfComparison = ({ subject, expected }: Assertion): boolean => {
+			if (subject === null) return false;
+			if (expected !== null && normalizedText(subject) === normalizedText(expected)) return true;
+
+			const inner = unwrapExpression(subject);
+			return (
+				inner.type === "BinaryExpression" &&
+				COMPARISON_OPERATORS.has(inner.operator) &&
+				inner.left.type !== "PrivateIdentifier" &&
+				normalizedText(inner.left) === normalizedText(inner.right)
+			);
+		};
+
+		const recordAssertion = (node: ESTree.CallExpression, { subject }: Assertion) => {
+			const frame = frames.at(-1);
+			if (frame === undefined || frame.node === node) return;
+			frame.assertions += 1;
+			if (subject === null) {
+				frame.mockOnly = false;
+				return;
+			}
+			const root = chainRoot(subject);
+			if (root.type !== "Identifier" || !mockNames.has(root.name)) frame.mockOnly = false;
+		};
+
+		const checkFunction = (node: FunctionLike) => {
+			if (!isPassThrough(node)) return;
+			context.report({ node, messageId: "passThroughWrapper" });
+		};
+
+		return {
+			VariableDeclarator(node) {
+				if (node.id.type !== "Identifier" || node.init === null) return;
+				if (isMockFactoryCall(node.init)) mockNames.add(node.id.name);
+			},
+			CallExpression(node) {
+				if (isTestCall(node)) frames.push({ node, assertions: 0, mockOnly: true });
+
+				const found = assertion(node);
+				if (found === null) return;
+				if (isSelfComparison(found)) {
+					context.report({ node, messageId: "tautologicalAssertion" });
+				}
+				recordAssertion(node, found);
+			},
+			"CallExpression:exit"(node) {
+				const frame = frames.at(-1);
+				if (frame === undefined || frame.node !== node) return;
+				frames.pop();
+				if (frame.assertions > 0 && frame.mockOnly) {
+					context.report({ node: node.callee, messageId: "mockOnlyAssertion" });
+				}
+			},
+			ArrowFunctionExpression: checkFunction,
+			FunctionDeclaration: checkFunction,
+			FunctionExpression: checkFunction,
+		};
+	},
+});

--- a/src/rules/no-self-licking.ts
+++ b/src/rules/no-self-licking.ts
@@ -123,7 +123,15 @@ function returnedExpression(node: FunctionLike): ESTree.Node | null {
 	return statement?.type === "ReturnStatement" ? statement.argument : null;
 }
 
+/** A function passed straight to a call is call-site syntax, not an indirection in the API surface. */
+function isInlineCallback(node: FunctionLike): boolean {
+	const parent = node.parent;
+	if (parent.type !== "CallExpression" && parent.type !== "NewExpression") return false;
+	return parent.callee !== node;
+}
+
 function isPassThrough(node: FunctionLike): boolean {
+	if (isInlineCallback(node)) return false;
 	const names = parameterNames(node);
 	const returned = returnedExpression(node);
 	if (names === null || returned === null) return false;


### PR DESCRIPTION
Two rules that target evidence fraud rather than type laundering: code that proves only itself, and code that claims work it never does. Both are AST-only, generic, and take no options.

## `no-self-licking`

- `tautologicalAssertion` — the assertion's two sides are the same source text, so it passes regardless of behavior: `expect(total).toBe(total)`, `assert.strictEqual(config, config)`, `assert(total === total)`. Covers `expect(...)` matcher chains (including `.not`/`.resolves`), `assert.*`, and bare `node:assert` equality functions.
- `mockOnlyAssertion` — every assertion subject inside an `it`/`test` callback resolves to a double created in the file (`vi.fn`, `jest.fn`, `sinon.stub`, `spyOn`, …). A single assertion against a real subject clears the test.
- `passThroughWrapper` — the body is one `return` that forwards the parameters unchanged (same arity and order) or returns a parameter as-is.

## `no-fraud`

- `fakeSuccess` — a function with parameters it never reads whose last statement returns a hardcoded success (`true`, or a literal-only object/array). Also fires when the body carries a `TODO`/`FIXME`/`not implemented` comment and still returns that success. Object literals that name a failure (`error`, `cause`, `failed`, …) or set `ok`/`success` to `false` are not success claims.
- `errorSwallowedSuccess` — a catch clause that never reads the caught binding, never rethrows, and returns only fabricated success.
- `placeholderData` — a small generic list of fixture-grade values (`example.com`, `lorem ipsum`, `John Doe`, `changeme`, …) in string and template literals.

`no-fraud` does not apply to test, mock, story, or fixture files, where fakes are honest.

## Trade-offs

Both rules are deliberately syntactic, so they accept some false positives that an opinionated plugin should reject anyway:

- identity arrows (`(value) => value`) and delegating methods are reported as pass-through;
- a predicate that ignores its argument and returns `true` is reported as fake success — prefix parameters with `_` to declare the intent;
- placeholder strings in a non-test helper are reported.

## Verification

`pnpm check` passes (lint, all RuleTester suites, `tsc --noEmit`, skill-asset drift). Both rules also ran end to end through `oxlint` against a fixture with one violation per message ID plus a near-miss for each: exactly six findings, no near-miss flagged. `pnpm sync:skill-assets` was run, so the bundled skill copy matches `src/`.