### PR TITLE
fix: tighten rule semantics and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ export default defineConfig({
 - `no-reflect-get` — rejects `Reflect.get` in favor of typed property access or boundary parsing.
 - `no-runtime-typeof` — requires boundary parsing instead of ad hoc `typeof` narrowing.
 - `no-shape-in-symbol-names` — rejects `shape` in symbol names.
-- `no-unknown-parameters` — rejects `unknown` inputs except the explicit `cause` convention.
+- `no-unknown-parameters` — rejects `unknown` inputs except the explicit `cause` convention and the subject of a type predicate.
 - `no-unknown-returns` — rejects function contracts that return `unknown` or `Promise<unknown>`.
 - `no-unknown-type-aliases` — rejects aliases that merely conceal `unknown`.
 - `no-unsafe-dictionary-type` — rejects dictionary value contracts based on `unknown`, `any`, `object`, `{}`, and semantic equivalents.
@@ -207,6 +207,9 @@ Import the owning Layer and yield `IssueService` instead. Focused `*.test.*` and
 ```ts
 function handle(input: unknown) {}
 ```
+
+A type predicate may accept `unknown` for the parameter it narrows; other `unknown`
+parameters on the same function remain rejected.
 
 ### `no-unknown-returns`
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export default defineConfig({
 
 - `no-chained-type-assertions` — rejects nested type assertions that fabricate evidence.
 - `no-conditional-empty-object-spread` — rejects conditional spreads that use `{}` to omit fields.
-- `no-known-value-widening` — rejects explicit broad target types that discard known value evidence.
+- `no-known-value-widening` — rejects explicit broad target types that discard known value evidence, including known arguments passed to local `unknown` type predicates.
 - `no-module-mocking` — rejects Vitest and Jest module mocks in favor of real dependency seams.
 - `no-object-parameters` — rejects the broad `object` type on function inputs.
 - `no-reflect-apply` — rejects `Reflect.apply` in favor of typed function calls.
@@ -139,6 +139,19 @@ const handlers: Record<string, Handler> = {
 ```
 
 This discards the known `start` key. Preserve inference or use `satisfies Record<string, Handler>` instead.
+
+Known values must not be widened back to `unknown` through a local type predicate:
+
+```ts
+function isUser(value: unknown): value is User {
+  return UserSchema.safeParse(value).success;
+}
+
+declare const user: User;
+isUser(user);
+```
+
+Call the predicate at the unparsed boundary, while the argument is still `unknown`.
 
 ### `no-module-mocking`
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "check": "pnpm lint && pnpm test && pnpm typecheck && pnpm check:skill-assets",
     "lint": "oxlint src",
-    "test": "tsx src/rules/no-conditional-empty-object-spread.test.ts && tsx src/rules/no-unsafe-dictionary-type.test.ts && tsx src/rules/no-known-value-widening.test.ts && tsx src/rules/no-object-parameters.test.ts && tsx src/rules/no-runtime-typeof.test.ts && tsx src/rules/no-unknown-returns.test.ts && tsx src/rules/no-unknown-type-aliases.test.ts && tsx src/rules/no-widen-then-assert.test.ts && tsx src/rules/no-reflect-get.test.ts && tsx src/rules/no-reflect-apply.test.ts && tsx src/rules/no-module-mocking.test.ts && tsx src/rules/require-safety-comment-for-type-assertion.test.ts && tsx src/effect/rules/no-service-constructor-imports.test.ts",
+    "test": "tsx src/rules/no-conditional-empty-object-spread.test.ts && tsx src/rules/no-unsafe-dictionary-type.test.ts && tsx src/rules/no-known-value-widening.test.ts && tsx src/rules/no-object-parameters.test.ts && tsx src/rules/no-unknown-parameters.test.ts && tsx src/rules/no-runtime-typeof.test.ts && tsx src/rules/no-unknown-returns.test.ts && tsx src/rules/no-unknown-type-aliases.test.ts && tsx src/rules/no-widen-then-assert.test.ts && tsx src/rules/no-reflect-get.test.ts && tsx src/rules/no-reflect-apply.test.ts && tsx src/rules/no-module-mocking.test.ts && tsx src/rules/require-safety-comment-for-type-assertion.test.ts && tsx src/effect/rules/no-service-constructor-imports.test.ts",
     "typecheck": "tsc --noEmit",
     "sync:skill-assets": "node scripts/sync-skill-assets.mjs",
     "check:skill-assets": "node scripts/sync-skill-assets.mjs --check"

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-known-value-widening.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-known-value-widening.ts
@@ -1,12 +1,18 @@
 import { defineRule } from "@oxlint/plugins";
 
 import {
+	classifyUnsafeDictionaryValue,
 	classifyWideningTarget,
 	createTypeEnvironment,
 	isKnownEvidenceExpression,
 	type TypeEnvironment,
 	type WideningTarget,
 } from "../shared/dictionary-types.ts";
+import {
+	containsUnknownType,
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
 
 import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
 
@@ -75,6 +81,140 @@ function hasKnownEvidence(
 	}
 	visitedVariables.add(variable);
 	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function isFunctionExpression(node: ESTree.Node): node is FunctionExpression {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression" ||
+		node.type === "TSDeclareFunction" ||
+		node.type === "TSEmptyBodyFunctionExpression"
+	);
+}
+
+function localFunctionForCall(
+	sourceCode: SourceCode,
+	callee: ESTree.Expression,
+): FunctionExpression | null {
+	const unwrapped = unwrapExpression(callee);
+	if (isFunctionExpression(unwrapped)) return unwrapped;
+	if (unwrapped.type !== "Identifier") return null;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (definition.type === "FunctionName" && isFunctionExpression(definition.node)) {
+		return definition.node;
+	}
+	if (definition.type !== "Variable" || definition.node.type !== "VariableDeclarator") {
+		return null;
+	}
+	const initializer = definition.node.init;
+	if (initializer === null) return null;
+	const unwrappedInitializer = unwrapExpression(initializer);
+	return isFunctionExpression(unwrappedInitializer) ? unwrappedInitializer : null;
+}
+
+function variableTypeAnnotation(
+	sourceCode: SourceCode,
+	variable: Variable,
+): ESTree.TSTypeAnnotation | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (
+		definition.type === "Variable" &&
+		definition.node.type === "VariableDeclarator" &&
+		definition.node.id.type === "Identifier"
+	) {
+		return definition.node.id.typeAnnotation ?? null;
+	}
+	if (definition.type !== "Parameter" || !isFunctionExpression(definition.node)) {
+		return null;
+	}
+	const parameter = definition.node.params.find(
+		(candidate) =>
+			functionParameterBindingName(candidate, sourceCode) === variable.name,
+	);
+	return parameter === undefined ? null : (functionParameterTypeAnnotation(parameter) ?? null);
+}
+
+function hasInformativeType(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): boolean {
+	return classifyUnsafeDictionaryValue(type, environment) === null;
+}
+
+function hasKnownCallArgumentEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	environment: TypeEnvironment,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (expression.type === "ParenthesizedExpression" || expression.type === "TSNonNullExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+		return hasInformativeType(expression.typeAnnotation, environment);
+	}
+	if (expression.type === "TSSatisfiesExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "CallExpression") {
+		const owner = localFunctionForCall(sourceCode, expression.callee);
+		const returnType = owner?.returnType?.typeAnnotation;
+		return returnType !== undefined && hasInformativeType(returnType, environment);
+	}
+	if (expression.type !== "Identifier") return isKnownEvidenceExpression(expression);
+	const variable = resolveVariable(sourceCode, expression);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const annotation = variableTypeAnnotation(sourceCode, variable);
+	if (annotation !== null) {
+		return hasInformativeType(annotation.typeAnnotation, environment);
+	}
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownCallArgumentEvidence(
+		sourceCode,
+		declarator.init,
+		environment,
+		visitedVariables,
+	);
+}
+
+function typePredicateSubjectIndex(
+	sourceCode: SourceCode,
+	owner: FunctionExpression,
+): number | null {
+	const predicate = owner.returnType?.typeAnnotation;
+	if (predicate?.type !== "TSTypePredicate" || predicate.parameterName.type !== "Identifier") {
+		return null;
+	}
+	const predicateParameterName = predicate.parameterName.name;
+	const index = owner.params.findIndex(
+		(parameter) =>
+			functionParameterBindingName(parameter, sourceCode) === predicateParameterName,
+	);
+	return index === -1 ? null : index;
 }
 
 function annotationTarget(
@@ -208,6 +348,43 @@ export const noKnownValueWideningRule = defineRule({
 					targetFromAnnotation(declarator.id.typeAnnotation),
 					`binding \`${declarator.id.name}\``,
 				);
+			},
+			CallExpression(node) {
+				if (environment === null) return;
+				const owner = localFunctionForCall(context.sourceCode, node.callee);
+				if (owner === null) return;
+				const parameterIndex = typePredicateSubjectIndex(context.sourceCode, owner);
+				if (parameterIndex === null) return;
+				const parameter = owner.params[parameterIndex];
+				const argument = node.arguments[parameterIndex];
+				if (parameter === undefined || argument === undefined || argument.type === "SpreadElement") {
+					return;
+				}
+				const parameterAnnotation = functionParameterTypeAnnotation(parameter);
+				if (
+					parameterAnnotation === null ||
+					parameterAnnotation === undefined ||
+					!containsUnknownType(parameterAnnotation.typeAnnotation)
+				) {
+					return;
+				}
+				if (
+					!hasKnownCallArgumentEvidence(
+						context.sourceCode,
+						argument,
+						environment,
+					)
+				) {
+					return;
+				}
+				context.report({
+					node: argument,
+					messageId: "widening",
+					data: {
+						subject: `argument for parameter \`${functionParameterBindingName(parameter, context.sourceCode)}\` of \`${functionName(context.sourceCode, owner)}\``,
+						target: "unknown",
+					},
+				});
 			},
 			ReturnStatement(node) {
 				if (node.argument === null) return;

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-object-parameters.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-object-parameters.ts
@@ -1,10 +1,12 @@
 import { defineRule } from "@oxlint/plugins";
 
-import type { ESTree, SourceCode } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
 
+import {
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
 import { lexicalTypeParameterNames } from "../shared/lexical-type-parameters.ts";
-
-type Parameter = ESTree.ParamPattern;
 type ParameterOwner =
 	| ESTree.ArrowFunctionExpression
 	| ESTree.Function
@@ -13,25 +15,6 @@ type ParameterOwner =
 	| ESTree.TSConstructorType
 	| ESTree.TSFunctionType
 	| ESTree.TSMethodSignature;
-
-function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
-	if (parameter.type === "TSParameterProperty") {
-		return parameterAnnotation(parameter.parameter);
-	}
-	if (parameter.type === "RestElement") {
-		return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
-	}
-	if (parameter.type === "AssignmentPattern") {
-		return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
-	}
-	return parameter.typeAnnotation;
-}
-
-function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
-	return parameter.type === "Identifier"
-		? parameter.name
-		: sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, "");
-}
 
 /** Ban the broad object type on function inputs, including local aliases to object. */
 export const noObjectParametersRule = defineRule({
@@ -86,13 +69,13 @@ export const noObjectParametersRule = defineRule({
 				context.sourceCode.visitorKeys,
 			);
 			for (const parameter of node.params) {
-				const annotation = parameterAnnotation(parameter);
+				const annotation = functionParameterTypeAnnotation(parameter);
 				if (annotation === null || annotation === undefined) continue;
 				if (!resolvesToObject(annotation.typeAnnotation, shadowedAliases)) continue;
 				context.report({
 					node: annotation.typeAnnotation,
 					messageId: "objectParameter",
-					data: { parameter: parameterName(parameter, context.sourceCode) },
+					data: { parameter: functionParameterBindingName(parameter, context.sourceCode) },
 				});
 			}
 		};

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-parameters.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-parameters.ts
@@ -2,6 +2,7 @@ import { defineRule } from "@oxlint/plugins";
 import type { ESTree } from "@oxlint/plugins";
 
 import {
+  containsUnknownType,
   functionParameterBindingName,
   functionParameterTypeAnnotation,
 } from "../shared/function-parameters.ts";
@@ -13,12 +14,6 @@ type ParameterOwner =
   | ESTree.TSConstructorType
   | ESTree.TSFunctionType
   | ESTree.TSMethodSignature;
-
-function containsUnknownType(type: ESTree.TSType): boolean {
-  if (type.type === "TSUnknownKeyword") return true;
-  if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
-  return type.type === "TSUnionType" && type.types.some(containsUnknownType);
-}
 
 function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
   const predicate = owner.returnType?.typeAnnotation;

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-parameters.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-parameters.ts
@@ -1,7 +1,10 @@
 import { defineRule } from "@oxlint/plugins";
 import type { ESTree } from "@oxlint/plugins";
 
-type Parameter = ESTree.ParamPattern;
+import {
+  functionParameterBindingName,
+  functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
 type ParameterOwner =
   | ESTree.ArrowFunctionExpression
   | ESTree.Function
@@ -11,32 +14,19 @@ type ParameterOwner =
   | ESTree.TSFunctionType
   | ESTree.TSMethodSignature;
 
-function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
-  if (parameter.type === "TSParameterProperty") {
-    return parameterAnnotation(parameter.parameter);
-  }
-  if (parameter.type === "RestElement") {
-    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
-  }
-  if (parameter.type === "AssignmentPattern") {
-    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
-  }
-  return parameter.typeAnnotation;
+function containsUnknownType(type: ESTree.TSType): boolean {
+  if (type.type === "TSUnknownKeyword") return true;
+  if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+  return type.type === "TSUnionType" && type.types.some(containsUnknownType);
 }
 
-function parameterName(parameter: Parameter, sourceText: string): string {
-  if (parameter.type === "TSParameterProperty") {
-    return parameterName(parameter.parameter, sourceText);
-  }
-  if (parameter.type === "AssignmentPattern") {
-    return parameterName(parameter.left, sourceText);
-  }
-  if (parameter.type === "RestElement") {
-    return parameterName(parameter.argument, sourceText);
-  }
-  return parameter.type === "Identifier"
-    ? parameter.name
-    : sourceText.replace(/\s*:\s*unknown\s*$/u, "");
+function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
+  const predicate = owner.returnType?.typeAnnotation;
+  return (
+    predicate?.type === "TSTypePredicate" &&
+    predicate.parameterName.type === "Identifier" &&
+    predicate.parameterName.name === parameterName
+  );
 }
 
 /** Disallow unknown inputs except explicitly named error-cause enrichment. */
@@ -45,7 +35,7 @@ export const noUnknownParametersRule = defineRule({
     type: "problem",
     docs: {
       description:
-        "Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.",
+        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
     },
     messages: {
       unknownParameter:
@@ -55,10 +45,11 @@ export const noUnknownParametersRule = defineRule({
   createOnce(context) {
     const checkParameters = (node: ParameterOwner) => {
       for (const parameter of node.params) {
-        const annotation = parameterAnnotation(parameter);
-        if (annotation?.typeAnnotation.type !== "TSUnknownKeyword") continue;
-        const name = parameterName(parameter, context.sourceCode.getText(parameter));
-        if (name === "cause") continue;
+        const annotation = functionParameterTypeAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!containsUnknownType(annotation.typeAnnotation)) continue;
+        const name = functionParameterBindingName(parameter, context.sourceCode);
+        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
         context.report({
           node: annotation.typeAnnotation,
           messageId: "unknownParameter",

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-type-aliases.ts
@@ -32,6 +32,8 @@ export const noUnknownTypeAliasesRule = defineRule({
 			if (type.type === "TSUnknownKeyword") return true;
 			if (type.type === "TSParenthesizedType")
 				return resolvesToUnknown(type.typeAnnotation, visited);
+			if (type.type === "TSUnionType")
+				return type.types.some((member) => resolvesToUnknown(member, visited));
 			const name = referencedAliasName(type);
 			if (name === null || visited.has(name)) return false;
 			const alias = aliases.get(name);

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -72,7 +72,19 @@ function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironme
 	return name !== null && environment.aliases.has(name) && !isInsideTypeAliasDeclaration(node);
 }
 
+function isInsideTypeParameterConstraint(node: ESTree.TSType): boolean {
+	let child: ESTree.Node = node;
+	let parent: ESTree.Node | null = child.parent;
+	while (parent !== null && parent.type !== "Program") {
+		if (parent.type === "TSTypeParameter" && parent.constraint === child) return true;
+		child = parent;
+		parent = child.parent;
+	}
+	return false;
+}
+
 function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isInsideTypeParameterConstraint(node)) return false;
 	if (isPlainAliasConsumerUse(node, environment)) return false;
 	if (classifyUnsafeDictionary(node, environment) === null) return false;
 	let current: ESTree.Node | null = node.parent;

--- a/skills/install-anti-slop/assets/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -20,17 +20,32 @@ function isConstAssertion(node: TypeAssertion): boolean {
   );
 }
 
+function hasSafetyJustificationBefore(
+  sourceCode: SourceCode,
+  owner: ESTree.Node,
+  assertion: TypeAssertion,
+): boolean {
+  return sourceCode
+    .getCommentsBefore(owner)
+    .some(
+      (comment) =>
+        comment.end <= assertion.start && /\bSAFETY\s*:\s*\S/u.test(comment.value),
+    );
+}
+
 function hasSafetyComment(sourceCode: SourceCode, node: TypeAssertion): boolean {
   let current: ESTree.Node = node;
   while (true) {
-    if (
-      sourceCode
-        .getCommentsBefore(current)
-        .some((comment) => comment.end <= node.start && /\bSAFETY\s*:/u.test(comment.value))
-    ) {
-      return true;
+    if (hasSafetyJustificationBefore(sourceCode, current, node)) return true;
+    if (commentOwnerKinds.has(current.type)) {
+      const exportDeclaration = current.parent;
+      return (
+        exportDeclaration.type === "ExportNamedDeclaration" &&
+        exportDeclaration.declaration === current &&
+        hasSafetyJustificationBefore(sourceCode, exportDeclaration, node)
+      );
     }
-    if (commentOwnerKinds.has(current.type) || current.parent.type === "Program") return false;
+    if (current.parent.type === "Program") return false;
     current = current.parent;
   }
 }

--- a/skills/install-anti-slop/assets/anti-slop/shared/dictionary-types.ts
+++ b/skills/install-anti-slop/assets/anti-slop/shared/dictionary-types.ts
@@ -328,15 +328,6 @@ export function classifyUnsafeDictionary(
 	return null;
 }
 
-function resolvesToDictionary(
-	type: ESTree.TSType,
-	environment: TypeEnvironment,
-	substitutions: TypeAliasEnvironment,
-	resolvingAliases: ReadonlySet<string>,
-): boolean {
-	return dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0;
-}
-
 export function classifyWideningTarget(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
@@ -359,15 +350,25 @@ export function classifyWideningTarget(
 		const wrapped = unwrapped.typeArguments?.params[0];
 		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
 	}
-	if (name === "Record" && isBuiltIn(name, environment)) return { kind: "open dictionary" };
+	if (name === "Record" && isBuiltIn(name, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, new Map())
+			? { kind: "open dictionary" }
+			: null;
+	}
 	const alias = environment.aliases.get(name);
 	if (alias === undefined) return null;
 	if ((alias.typeParameters?.params.length ?? 0) > 0) {
 		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
-		return substitutions !== null &&
-			resolvesToDictionary(alias.typeAnnotation, environment, substitutions, new Set([name]))
-			? { kind: "generic container" }
-			: null;
+		const resolved =
+			substitutions === null
+				? null
+				: classifyAliasBroadTarget(
+						alias.typeAnnotation,
+						environment,
+						substitutions,
+						new Set([name]),
+					);
+		return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
 	}
 	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
 	if (substitutions === null) return null;
@@ -380,10 +381,20 @@ export function classifyWideningTarget(
 	return resolved;
 }
 
+function hasBroadRecordKey(
+	type: ESTree.TSTypeReference,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const key = type.typeArguments?.params[0];
+	return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+
 function isBroadMappedKey(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
 	substitutions: TypeAliasEnvironment,
+	visitedAliases: ReadonlySet<string> = new Set(),
 ): boolean {
 	const unwrapped = unwrapTransparentType(type);
 	if (
@@ -394,8 +405,8 @@ function isBroadMappedKey(
 		return true;
 	}
 	if (unwrapped.type === "TSUnionType") {
-		return unwrapped.types.every((member) =>
-			isBroadMappedKey(member, environment, substitutions),
+		return unwrapped.types.some((member) =>
+			isBroadMappedKey(member, environment, substitutions, visitedAliases),
 		);
 	}
 	if (unwrapped.type !== "TSTypeReference") return false;
@@ -403,9 +414,20 @@ function isBroadMappedKey(
 	if (name === null) return false;
 	const substitution = substitutions.get(name);
 	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
-		return isBroadMappedKey(substitution, environment, substitutions);
+		return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
 	}
-	return name === "PropertyKey" && isBuiltIn(name, environment);
+	if (name === "PropertyKey" && isBuiltIn(name, environment)) return true;
+	const alias = environment.aliases.get(name);
+	if (
+		alias === undefined ||
+		(alias.typeParameters?.params.length ?? 0) > 0 ||
+		visitedAliases.has(name)
+	) {
+		return false;
+	}
+	const nextVisited = new Set(visitedAliases);
+	nextVisited.add(name);
+	return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
 }
 
 function classifyAliasBroadTarget(
@@ -448,7 +470,9 @@ function classifyAliasBroadTarget(
 			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
 	}
 	if (name === "Record" && isBuiltIn(name, environment)) {
-		return { kind: "open dictionary" };
+		return hasBroadRecordKey(unwrapped, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
 	}
 	const alias = environment.aliases.get(name);
 	if (alias === undefined || resolvingAliases.has(name)) return null;

--- a/skills/install-anti-slop/assets/anti-slop/shared/function-parameters.ts
+++ b/skills/install-anti-slop/assets/anti-slop/shared/function-parameters.ts
@@ -2,6 +2,13 @@ import type { ESTree, SourceCode } from "@oxlint/plugins";
 
 export type FunctionParameter = ESTree.ParamPattern;
 
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export function containsUnknownType(type: ESTree.TSType): boolean {
+	if (type.type === "TSUnknownKeyword") return true;
+	if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+	return type.type === "TSUnionType" && type.types.some(containsUnknownType);
+}
+
 /** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
 export function functionParameterTypeAnnotation(
 	parameter: FunctionParameter,

--- a/skills/install-anti-slop/assets/anti-slop/shared/function-parameters.ts
+++ b/skills/install-anti-slop/assets/anti-slop/shared/function-parameters.ts
@@ -1,0 +1,42 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+export type FunctionParameter = ESTree.ParamPattern;
+
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export function functionParameterTypeAnnotation(
+	parameter: FunctionParameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterTypeAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.left);
+	}
+	return parameter.typeAnnotation;
+}
+
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export function functionParameterBindingName(
+	parameter: FunctionParameter,
+	sourceCode: SourceCode,
+): string {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterBindingName(parameter.parameter, sourceCode);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return functionParameterBindingName(parameter.left, sourceCode);
+	}
+	if (parameter.type === "RestElement") {
+		return functionParameterBindingName(parameter.argument, sourceCode);
+	}
+	if (parameter.type === "Identifier") return parameter.name;
+
+	const sourceText = sourceCode.getText(parameter);
+	const annotationStart = parameter.typeAnnotation?.start;
+	return annotationStart === undefined
+		? sourceText
+		: sourceText.slice(0, annotationStart - parameter.start).trimEnd();
+}

--- a/src/rules/no-known-value-widening.test.ts
+++ b/src/rules/no-known-value-widening.test.ts
@@ -35,6 +35,9 @@ tester.run("anti-slop/no-known-value-widening", noKnownValueWideningRule, {
 		`${prelude} type Diet = 'vegan' | 'omnivore'; const labels: Readonly<Record<Diet, string>> = { vegan: 'V', omnivore: 'O' };`,
 		`${prelude} const labels: Record<'a' | 'b', number> = { a: 1, b: 2 };`,
 		`${prelude} type Index<Key extends PropertyKey, Value> = Record<Key, Value>; const commands: Index<'start', Command> = { start: startCommand };`,
+		"function isString(value: unknown): value is string { return true; } declare const input: unknown; isString(input);",
+		"function isString(value: string | unknown): value is string { return true; } declare const input: string | unknown; isString(input);",
+		"function isString(value: unknown): value is string { return true; } declare function readInput(): unknown; isString(readInput());",
 	],
 	invalid: [
 		{ code: "const value: unknown = {};", errors: [error] },
@@ -127,5 +130,29 @@ tester.run("anti-slop/no-known-value-widening", noKnownValueWideningRule, {
 		},
 		{ code: "const value: unknown = 1;", errors: [error] },
 		{ code: "const value: object = [];", errors: [error] },
+		{
+			code: "function isString(value: unknown): value is string { return true; } isString('known');",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: unknown): value is string { return true; } const known = 'known'; isString(known);",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: string | unknown): value is string { return true; } isString('known');",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: unknown): value is string { return true; } function check(known: string): boolean { return isString(known); }",
+			errors: [error],
+		},
+		{
+			code: "const isString = (value: unknown): value is string => true; const known: string = getValue(); isString(known);",
+			errors: [error],
+		},
+		{
+			code: "type User = { readonly id: string }; function isUser(value: unknown): value is User { return true; } function parse(): User { return { id: 'known' }; } const user = parse(); isUser(user);",
+			errors: [error],
+		},
 	],
 });

--- a/src/rules/no-known-value-widening.test.ts
+++ b/src/rules/no-known-value-widening.test.ts
@@ -30,6 +30,11 @@ tester.run("anti-slop/no-known-value-widening", noKnownValueWideningRule, {
 		`${prelude} interface Commands { readonly start: Command } function create(): Commands { return { start: startCommand }; }`,
 		`${prelude} declare function make(): Record<string, Command>; const commands: Record<string, Command> = make();`,
 		`${prelude} import { Commands } from './types'; const commands: Commands = { start: startCommand };`,
+		`${prelude} type Diet = 'vegan' | 'omnivore'; const labels: Record<Diet, string> = { vegan: 'V', omnivore: 'O' };`,
+		`${prelude} type Diet = 'vegan' | 'omnivore'; type Labels = Record<Diet, string>; const labels: Labels = { vegan: 'V', omnivore: 'O' };`,
+		`${prelude} type Diet = 'vegan' | 'omnivore'; const labels: Readonly<Record<Diet, string>> = { vegan: 'V', omnivore: 'O' };`,
+		`${prelude} const labels: Record<'a' | 'b', number> = { a: 1, b: 2 };`,
+		`${prelude} type Index<Key extends PropertyKey, Value> = Record<Key, Value>; const commands: Index<'start', Command> = { start: startCommand };`,
 	],
 	invalid: [
 		{ code: "const value: unknown = {};", errors: [error] },
@@ -106,6 +111,18 @@ tester.run("anti-slop/no-known-value-widening", noKnownValueWideningRule, {
 		},
 		{
 			code: `${prelude} type Index<T = Command> = Record<string, T>; const commands: Index = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Key = string; const commands: Record<Key, Command> = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands: Record<PropertyKey, Command> = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands: Record<string | 'start', Command> = { start: startCommand };`,
 			errors: [error],
 		},
 		{ code: "const value: unknown = 1;", errors: [error] },

--- a/src/rules/no-known-value-widening.ts
+++ b/src/rules/no-known-value-widening.ts
@@ -1,12 +1,18 @@
 import { defineRule } from "@oxlint/plugins";
 
 import {
+	classifyUnsafeDictionaryValue,
 	classifyWideningTarget,
 	createTypeEnvironment,
 	isKnownEvidenceExpression,
 	type TypeEnvironment,
 	type WideningTarget,
 } from "../shared/dictionary-types.ts";
+import {
+	containsUnknownType,
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
 
 import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
 
@@ -75,6 +81,140 @@ function hasKnownEvidence(
 	}
 	visitedVariables.add(variable);
 	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function isFunctionExpression(node: ESTree.Node): node is FunctionExpression {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression" ||
+		node.type === "TSDeclareFunction" ||
+		node.type === "TSEmptyBodyFunctionExpression"
+	);
+}
+
+function localFunctionForCall(
+	sourceCode: SourceCode,
+	callee: ESTree.Expression,
+): FunctionExpression | null {
+	const unwrapped = unwrapExpression(callee);
+	if (isFunctionExpression(unwrapped)) return unwrapped;
+	if (unwrapped.type !== "Identifier") return null;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (definition.type === "FunctionName" && isFunctionExpression(definition.node)) {
+		return definition.node;
+	}
+	if (definition.type !== "Variable" || definition.node.type !== "VariableDeclarator") {
+		return null;
+	}
+	const initializer = definition.node.init;
+	if (initializer === null) return null;
+	const unwrappedInitializer = unwrapExpression(initializer);
+	return isFunctionExpression(unwrappedInitializer) ? unwrappedInitializer : null;
+}
+
+function variableTypeAnnotation(
+	sourceCode: SourceCode,
+	variable: Variable,
+): ESTree.TSTypeAnnotation | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (
+		definition.type === "Variable" &&
+		definition.node.type === "VariableDeclarator" &&
+		definition.node.id.type === "Identifier"
+	) {
+		return definition.node.id.typeAnnotation ?? null;
+	}
+	if (definition.type !== "Parameter" || !isFunctionExpression(definition.node)) {
+		return null;
+	}
+	const parameter = definition.node.params.find(
+		(candidate) =>
+			functionParameterBindingName(candidate, sourceCode) === variable.name,
+	);
+	return parameter === undefined ? null : (functionParameterTypeAnnotation(parameter) ?? null);
+}
+
+function hasInformativeType(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): boolean {
+	return classifyUnsafeDictionaryValue(type, environment) === null;
+}
+
+function hasKnownCallArgumentEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	environment: TypeEnvironment,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (expression.type === "ParenthesizedExpression" || expression.type === "TSNonNullExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+		return hasInformativeType(expression.typeAnnotation, environment);
+	}
+	if (expression.type === "TSSatisfiesExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "CallExpression") {
+		const owner = localFunctionForCall(sourceCode, expression.callee);
+		const returnType = owner?.returnType?.typeAnnotation;
+		return returnType !== undefined && hasInformativeType(returnType, environment);
+	}
+	if (expression.type !== "Identifier") return isKnownEvidenceExpression(expression);
+	const variable = resolveVariable(sourceCode, expression);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const annotation = variableTypeAnnotation(sourceCode, variable);
+	if (annotation !== null) {
+		return hasInformativeType(annotation.typeAnnotation, environment);
+	}
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownCallArgumentEvidence(
+		sourceCode,
+		declarator.init,
+		environment,
+		visitedVariables,
+	);
+}
+
+function typePredicateSubjectIndex(
+	sourceCode: SourceCode,
+	owner: FunctionExpression,
+): number | null {
+	const predicate = owner.returnType?.typeAnnotation;
+	if (predicate?.type !== "TSTypePredicate" || predicate.parameterName.type !== "Identifier") {
+		return null;
+	}
+	const predicateParameterName = predicate.parameterName.name;
+	const index = owner.params.findIndex(
+		(parameter) =>
+			functionParameterBindingName(parameter, sourceCode) === predicateParameterName,
+	);
+	return index === -1 ? null : index;
 }
 
 function annotationTarget(
@@ -208,6 +348,43 @@ export const noKnownValueWideningRule = defineRule({
 					targetFromAnnotation(declarator.id.typeAnnotation),
 					`binding \`${declarator.id.name}\``,
 				);
+			},
+			CallExpression(node) {
+				if (environment === null) return;
+				const owner = localFunctionForCall(context.sourceCode, node.callee);
+				if (owner === null) return;
+				const parameterIndex = typePredicateSubjectIndex(context.sourceCode, owner);
+				if (parameterIndex === null) return;
+				const parameter = owner.params[parameterIndex];
+				const argument = node.arguments[parameterIndex];
+				if (parameter === undefined || argument === undefined || argument.type === "SpreadElement") {
+					return;
+				}
+				const parameterAnnotation = functionParameterTypeAnnotation(parameter);
+				if (
+					parameterAnnotation === null ||
+					parameterAnnotation === undefined ||
+					!containsUnknownType(parameterAnnotation.typeAnnotation)
+				) {
+					return;
+				}
+				if (
+					!hasKnownCallArgumentEvidence(
+						context.sourceCode,
+						argument,
+						environment,
+					)
+				) {
+					return;
+				}
+				context.report({
+					node: argument,
+					messageId: "widening",
+					data: {
+						subject: `argument for parameter \`${functionParameterBindingName(parameter, context.sourceCode)}\` of \`${functionName(context.sourceCode, owner)}\``,
+						target: "unknown",
+					},
+				});
 			},
 			ReturnStatement(node) {
 				if (node.argument === null) return;

--- a/src/rules/no-object-parameters.test.ts
+++ b/src/rules/no-object-parameters.test.ts
@@ -28,5 +28,17 @@ tester.run("anti-slop/no-object-parameters", noObjectParametersRule, {
 			code: "type Item = object; type Fallback<Input> = Input extends infer Item ? string : (value: Item) => void;",
 			errors: [error],
 		},
+		{
+			code: "function consume(value: object = {}): void {}",
+			errors: [{ ...error, data: { parameter: "value" } }],
+		},
+		{
+			code: "function consume({ value }: object = {}): void {}",
+			errors: [{ ...error, data: { parameter: "{ value }" } }],
+		},
+		{
+			code: "type Bag = object; function consume({ value }: Bag): void {}",
+			errors: [{ ...error, data: { parameter: "{ value }" } }],
+		},
 	],
 });

--- a/src/rules/no-object-parameters.ts
+++ b/src/rules/no-object-parameters.ts
@@ -1,10 +1,12 @@
 import { defineRule } from "@oxlint/plugins";
 
-import type { ESTree, SourceCode } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
 
+import {
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
 import { lexicalTypeParameterNames } from "../shared/lexical-type-parameters.ts";
-
-type Parameter = ESTree.ParamPattern;
 type ParameterOwner =
 	| ESTree.ArrowFunctionExpression
 	| ESTree.Function
@@ -13,25 +15,6 @@ type ParameterOwner =
 	| ESTree.TSConstructorType
 	| ESTree.TSFunctionType
 	| ESTree.TSMethodSignature;
-
-function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
-	if (parameter.type === "TSParameterProperty") {
-		return parameterAnnotation(parameter.parameter);
-	}
-	if (parameter.type === "RestElement") {
-		return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
-	}
-	if (parameter.type === "AssignmentPattern") {
-		return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
-	}
-	return parameter.typeAnnotation;
-}
-
-function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
-	return parameter.type === "Identifier"
-		? parameter.name
-		: sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, "");
-}
 
 /** Ban the broad object type on function inputs, including local aliases to object. */
 export const noObjectParametersRule = defineRule({
@@ -86,13 +69,13 @@ export const noObjectParametersRule = defineRule({
 				context.sourceCode.visitorKeys,
 			);
 			for (const parameter of node.params) {
-				const annotation = parameterAnnotation(parameter);
+				const annotation = functionParameterTypeAnnotation(parameter);
 				if (annotation === null || annotation === undefined) continue;
 				if (!resolvesToObject(annotation.typeAnnotation, shadowedAliases)) continue;
 				context.report({
 					node: annotation.typeAnnotation,
 					messageId: "objectParameter",
-					data: { parameter: parameterName(parameter, context.sourceCode) },
+					data: { parameter: functionParameterBindingName(parameter, context.sourceCode) },
 				});
 			}
 		};

--- a/src/rules/no-unknown-parameters.test.ts
+++ b/src/rules/no-unknown-parameters.test.ts
@@ -1,0 +1,36 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noUnknownParametersRule } from "./no-unknown-parameters.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "unknownParameter" };
+
+tester.run("anti-slop/no-unknown-parameters", noUnknownParametersRule, {
+	valid: [
+		"function enrich(cause: unknown): void {}",
+		"function enrich(cause: Error | unknown): void {}",
+		"function isString(value: unknown): value is string { return true; }",
+		"const isString = (value: unknown): value is string => true;",
+		"function assertString(value: unknown): asserts value is string {}",
+		"type Guard = (value: unknown) => value is string;",
+		"declare function isString(value: unknown): value is string;",
+		"type Guards = { isString(value: unknown): value is string };",
+		"function parse(value: string | number): void {}",
+	],
+	invalid: [
+		{ code: "function parse(value: unknown): void {}", errors: [error] },
+		{ code: "function parse(value: string | unknown): void {}", errors: [error] },
+		{
+			code: "function parse(value: string | (number | unknown)): void {}",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: unknown, context: unknown): value is string { return true; }",
+			errors: [{ ...error, data: { parameter: "context" } }],
+		},
+		{
+			code: "export function parse({ value }: unknown = {}): void {}",
+			errors: [{ ...error, data: { parameter: "{ value }" } }],
+		},
+	],
+});

--- a/src/rules/no-unknown-parameters.ts
+++ b/src/rules/no-unknown-parameters.ts
@@ -2,6 +2,7 @@ import { defineRule } from "@oxlint/plugins";
 import type { ESTree } from "@oxlint/plugins";
 
 import {
+  containsUnknownType,
   functionParameterBindingName,
   functionParameterTypeAnnotation,
 } from "../shared/function-parameters.ts";
@@ -13,12 +14,6 @@ type ParameterOwner =
   | ESTree.TSConstructorType
   | ESTree.TSFunctionType
   | ESTree.TSMethodSignature;
-
-function containsUnknownType(type: ESTree.TSType): boolean {
-  if (type.type === "TSUnknownKeyword") return true;
-  if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
-  return type.type === "TSUnionType" && type.types.some(containsUnknownType);
-}
 
 function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
   const predicate = owner.returnType?.typeAnnotation;

--- a/src/rules/no-unknown-parameters.ts
+++ b/src/rules/no-unknown-parameters.ts
@@ -1,7 +1,10 @@
 import { defineRule } from "@oxlint/plugins";
 import type { ESTree } from "@oxlint/plugins";
 
-type Parameter = ESTree.ParamPattern;
+import {
+  functionParameterBindingName,
+  functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
 type ParameterOwner =
   | ESTree.ArrowFunctionExpression
   | ESTree.Function
@@ -11,32 +14,19 @@ type ParameterOwner =
   | ESTree.TSFunctionType
   | ESTree.TSMethodSignature;
 
-function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
-  if (parameter.type === "TSParameterProperty") {
-    return parameterAnnotation(parameter.parameter);
-  }
-  if (parameter.type === "RestElement") {
-    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
-  }
-  if (parameter.type === "AssignmentPattern") {
-    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
-  }
-  return parameter.typeAnnotation;
+function containsUnknownType(type: ESTree.TSType): boolean {
+  if (type.type === "TSUnknownKeyword") return true;
+  if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+  return type.type === "TSUnionType" && type.types.some(containsUnknownType);
 }
 
-function parameterName(parameter: Parameter, sourceText: string): string {
-  if (parameter.type === "TSParameterProperty") {
-    return parameterName(parameter.parameter, sourceText);
-  }
-  if (parameter.type === "AssignmentPattern") {
-    return parameterName(parameter.left, sourceText);
-  }
-  if (parameter.type === "RestElement") {
-    return parameterName(parameter.argument, sourceText);
-  }
-  return parameter.type === "Identifier"
-    ? parameter.name
-    : sourceText.replace(/\s*:\s*unknown\s*$/u, "");
+function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
+  const predicate = owner.returnType?.typeAnnotation;
+  return (
+    predicate?.type === "TSTypePredicate" &&
+    predicate.parameterName.type === "Identifier" &&
+    predicate.parameterName.name === parameterName
+  );
 }
 
 /** Disallow unknown inputs except explicitly named error-cause enrichment. */
@@ -45,7 +35,7 @@ export const noUnknownParametersRule = defineRule({
     type: "problem",
     docs: {
       description:
-        "Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.",
+        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
     },
     messages: {
       unknownParameter:
@@ -55,10 +45,11 @@ export const noUnknownParametersRule = defineRule({
   createOnce(context) {
     const checkParameters = (node: ParameterOwner) => {
       for (const parameter of node.params) {
-        const annotation = parameterAnnotation(parameter);
-        if (annotation?.typeAnnotation.type !== "TSUnknownKeyword") continue;
-        const name = parameterName(parameter, context.sourceCode.getText(parameter));
-        if (name === "cause") continue;
+        const annotation = functionParameterTypeAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!containsUnknownType(annotation.typeAnnotation)) continue;
+        const name = functionParameterBindingName(parameter, context.sourceCode);
+        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
         context.report({
           node: annotation.typeAnnotation,
           messageId: "unknownParameter",

--- a/src/rules/no-unknown-type-aliases.test.ts
+++ b/src/rules/no-unknown-type-aliases.test.ts
@@ -9,10 +9,16 @@ tester.run("anti-slop/no-unknown-type-aliases", noUnknownTypeAliasesRule, {
 	valid: [
 		"type User = { readonly id: string };",
 		"type Alias = string; type UserId = Alias;",
+		"type Payload = string | number;",
 	],
 	invalid: [
 		{ code: "type Alias = unknown;", errors: [error] },
 		{ code: "type Current = unknown;", errors: [error] },
 		{ code: "type UnknownValue = unknown; type Alias = UnknownValue;", errors: [error, error] },
+		{ code: "type Payload = string | unknown;", errors: [error] },
+		{
+			code: "type Payload = string | unknown; type NestedPayload = number | Payload;",
+			errors: [error, error],
+		},
 	],
 });

--- a/src/rules/no-unknown-type-aliases.ts
+++ b/src/rules/no-unknown-type-aliases.ts
@@ -32,6 +32,8 @@ export const noUnknownTypeAliasesRule = defineRule({
 			if (type.type === "TSUnknownKeyword") return true;
 			if (type.type === "TSParenthesizedType")
 				return resolvesToUnknown(type.typeAnnotation, visited);
+			if (type.type === "TSUnionType")
+				return type.types.some((member) => resolvesToUnknown(member, visited));
 			const name = referencedAliasName(type);
 			if (name === null || visited.has(name)) return false;
 			const alias = aliases.get(name);

--- a/src/rules/no-unsafe-dictionary-type.test.ts
+++ b/src/rules/no-unsafe-dictionary-type.test.ts
@@ -31,6 +31,10 @@ tester.run("anti-slop/no-unsafe-dictionary-type", noUnsafeDictionaryTypeRule, {
 		"interface Escape { readonly id: string } interface Escape {} type A = Record<string, Escape>;",
 		"interface Owner { readonly id: string } type A = Record<string, object & Owner>;",
 		"type Wrap<T> = { readonly wrapped: T }; type Inner<T, U> = { readonly value: T } & Wrap<U>; type Outer<T, U> = Record<string, Inner<T, U>>; declare function f<T, U>(): Outer<T, U>;",
+		"type WithSchema<T extends Record<string, unknown>> = (schema: T) => void;",
+		"function run<T extends Record<string, unknown>>(input: T): T { return input; }",
+		"declare class Store<T extends Record<string, unknown>> { read(): T }",
+		"type Deep<T extends Readonly<Record<string, unknown>>> = T;",
 	],
 	invalid: [
 		{ code: "type A = Record<string, unknown>;", errors: [error] },

--- a/src/rules/no-unsafe-dictionary-type.ts
+++ b/src/rules/no-unsafe-dictionary-type.ts
@@ -72,7 +72,19 @@ function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironme
 	return name !== null && environment.aliases.has(name) && !isInsideTypeAliasDeclaration(node);
 }
 
+function isInsideTypeParameterConstraint(node: ESTree.TSType): boolean {
+	let child: ESTree.Node = node;
+	let parent: ESTree.Node | null = child.parent;
+	while (parent !== null && parent.type !== "Program") {
+		if (parent.type === "TSTypeParameter" && parent.constraint === child) return true;
+		child = parent;
+		parent = child.parent;
+	}
+	return false;
+}
+
 function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isInsideTypeParameterConstraint(node)) return false;
 	if (isPlainAliasConsumerUse(node, environment)) return false;
 	if (classifyUnsafeDictionary(node, environment) === null) return false;
 	let current: ESTree.Node | null = node.parent;

--- a/src/rules/require-safety-comment-for-type-assertion.test.ts
+++ b/src/rules/require-safety-comment-for-type-assertion.test.ts
@@ -15,6 +15,8 @@ tester.run(
       "// SAFETY: The parser established the UserId invariant.\nconst id = value as UserId;",
       "function parse(): UserId {\n// SAFETY: Validation above established the UserId invariant.\nreturn value as UserId;\n}",
       "const id = /* SAFETY: Validation established the invariant. */ value as UserId;",
+      "// SAFETY: The parser established the exported UserId invariant.\nexport const id = value as UserId;",
+      "/* SAFETY:\n * The parser established the exported UserId invariant.\n */\nexport const id = value as UserId;",
     ],
     invalid: [
       { code: "const id = value as UserId;", errors: [error] },
@@ -22,6 +24,14 @@ tester.run(
       { code: "const id = value as UserId; // SAFETY: Too late.", errors: [error] },
       {
         code: "// This cast seems fine.\nconst id = value as UserId;",
+        errors: [error],
+      },
+      { code: "// SAFETY:\nconst id = value as UserId;", errors: [error] },
+      { code: "// SAFETY:   \nconst id = value as UserId;", errors: [error] },
+      { code: "const id = /* SAFETY: */ value as UserId;", errors: [error] },
+      { code: "export const id = value as UserId;", errors: [error] },
+      {
+        code: "// This is not a safety justification.\nexport const id = value as UserId;",
         errors: [error],
       },
     ],

--- a/src/rules/require-safety-comment-for-type-assertion.ts
+++ b/src/rules/require-safety-comment-for-type-assertion.ts
@@ -20,17 +20,32 @@ function isConstAssertion(node: TypeAssertion): boolean {
   );
 }
 
+function hasSafetyJustificationBefore(
+  sourceCode: SourceCode,
+  owner: ESTree.Node,
+  assertion: TypeAssertion,
+): boolean {
+  return sourceCode
+    .getCommentsBefore(owner)
+    .some(
+      (comment) =>
+        comment.end <= assertion.start && /\bSAFETY\s*:\s*\S/u.test(comment.value),
+    );
+}
+
 function hasSafetyComment(sourceCode: SourceCode, node: TypeAssertion): boolean {
   let current: ESTree.Node = node;
   while (true) {
-    if (
-      sourceCode
-        .getCommentsBefore(current)
-        .some((comment) => comment.end <= node.start && /\bSAFETY\s*:/u.test(comment.value))
-    ) {
-      return true;
+    if (hasSafetyJustificationBefore(sourceCode, current, node)) return true;
+    if (commentOwnerKinds.has(current.type)) {
+      const exportDeclaration = current.parent;
+      return (
+        exportDeclaration.type === "ExportNamedDeclaration" &&
+        exportDeclaration.declaration === current &&
+        hasSafetyJustificationBefore(sourceCode, exportDeclaration, node)
+      );
     }
-    if (commentOwnerKinds.has(current.type) || current.parent.type === "Program") return false;
+    if (current.parent.type === "Program") return false;
     current = current.parent;
   }
 }

--- a/src/shared/dictionary-types.ts
+++ b/src/shared/dictionary-types.ts
@@ -328,15 +328,6 @@ export function classifyUnsafeDictionary(
 	return null;
 }
 
-function resolvesToDictionary(
-	type: ESTree.TSType,
-	environment: TypeEnvironment,
-	substitutions: TypeAliasEnvironment,
-	resolvingAliases: ReadonlySet<string>,
-): boolean {
-	return dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0;
-}
-
 export function classifyWideningTarget(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
@@ -359,15 +350,25 @@ export function classifyWideningTarget(
 		const wrapped = unwrapped.typeArguments?.params[0];
 		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
 	}
-	if (name === "Record" && isBuiltIn(name, environment)) return { kind: "open dictionary" };
+	if (name === "Record" && isBuiltIn(name, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, new Map())
+			? { kind: "open dictionary" }
+			: null;
+	}
 	const alias = environment.aliases.get(name);
 	if (alias === undefined) return null;
 	if ((alias.typeParameters?.params.length ?? 0) > 0) {
 		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
-		return substitutions !== null &&
-			resolvesToDictionary(alias.typeAnnotation, environment, substitutions, new Set([name]))
-			? { kind: "generic container" }
-			: null;
+		const resolved =
+			substitutions === null
+				? null
+				: classifyAliasBroadTarget(
+						alias.typeAnnotation,
+						environment,
+						substitutions,
+						new Set([name]),
+					);
+		return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
 	}
 	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
 	if (substitutions === null) return null;
@@ -380,10 +381,20 @@ export function classifyWideningTarget(
 	return resolved;
 }
 
+function hasBroadRecordKey(
+	type: ESTree.TSTypeReference,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const key = type.typeArguments?.params[0];
+	return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+
 function isBroadMappedKey(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
 	substitutions: TypeAliasEnvironment,
+	visitedAliases: ReadonlySet<string> = new Set(),
 ): boolean {
 	const unwrapped = unwrapTransparentType(type);
 	if (
@@ -394,8 +405,8 @@ function isBroadMappedKey(
 		return true;
 	}
 	if (unwrapped.type === "TSUnionType") {
-		return unwrapped.types.every((member) =>
-			isBroadMappedKey(member, environment, substitutions),
+		return unwrapped.types.some((member) =>
+			isBroadMappedKey(member, environment, substitutions, visitedAliases),
 		);
 	}
 	if (unwrapped.type !== "TSTypeReference") return false;
@@ -403,9 +414,20 @@ function isBroadMappedKey(
 	if (name === null) return false;
 	const substitution = substitutions.get(name);
 	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
-		return isBroadMappedKey(substitution, environment, substitutions);
+		return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
 	}
-	return name === "PropertyKey" && isBuiltIn(name, environment);
+	if (name === "PropertyKey" && isBuiltIn(name, environment)) return true;
+	const alias = environment.aliases.get(name);
+	if (
+		alias === undefined ||
+		(alias.typeParameters?.params.length ?? 0) > 0 ||
+		visitedAliases.has(name)
+	) {
+		return false;
+	}
+	const nextVisited = new Set(visitedAliases);
+	nextVisited.add(name);
+	return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
 }
 
 function classifyAliasBroadTarget(
@@ -448,7 +470,9 @@ function classifyAliasBroadTarget(
 			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
 	}
 	if (name === "Record" && isBuiltIn(name, environment)) {
-		return { kind: "open dictionary" };
+		return hasBroadRecordKey(unwrapped, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
 	}
 	const alias = environment.aliases.get(name);
 	if (alias === undefined || resolvingAliases.has(name)) return null;

--- a/src/shared/function-parameters.ts
+++ b/src/shared/function-parameters.ts
@@ -2,6 +2,13 @@ import type { ESTree, SourceCode } from "@oxlint/plugins";
 
 export type FunctionParameter = ESTree.ParamPattern;
 
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export function containsUnknownType(type: ESTree.TSType): boolean {
+	if (type.type === "TSUnknownKeyword") return true;
+	if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+	return type.type === "TSUnionType" && type.types.some(containsUnknownType);
+}
+
 /** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
 export function functionParameterTypeAnnotation(
 	parameter: FunctionParameter,

--- a/src/shared/function-parameters.ts
+++ b/src/shared/function-parameters.ts
@@ -1,0 +1,42 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+export type FunctionParameter = ESTree.ParamPattern;
+
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export function functionParameterTypeAnnotation(
+	parameter: FunctionParameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterTypeAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.left);
+	}
+	return parameter.typeAnnotation;
+}
+
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export function functionParameterBindingName(
+	parameter: FunctionParameter,
+	sourceCode: SourceCode,
+): string {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterBindingName(parameter.parameter, sourceCode);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return functionParameterBindingName(parameter.left, sourceCode);
+	}
+	if (parameter.type === "RestElement") {
+		return functionParameterBindingName(parameter.argument, sourceCode);
+	}
+	if (parameter.type === "Identifier") return parameter.name;
+
+	const sourceText = sourceCode.getText(parameter);
+	const annotationStart = parameter.typeAnnotation?.start;
+	return annotationStart === undefined
+		? sourceText
+		: sourceText.slice(0, annotationStart - parameter.start).trimEnd();
+}


### PR DESCRIPTION
## Summary

- require non-empty `SAFETY:` justifications and recognize comments above exported variable declarations
- allow `unknown` only for the parameter named by a type predicate, reject other unknown parameters, and prevent known values from being widened back to `unknown` at local predicate call sites
- detect unions containing `unknown` in parameter and type-alias rules
- treat only open-key `Record` targets as evidence-losing widening
- exempt generic type-parameter constraints from unsafe dictionary reports
- report parameter binding names without annotations or default values
- add focused RuleTester coverage and keep vendored skill assets synchronized

## Issue details

- #15: type predicates can accept an `unknown` subject; unrelated `unknown` parameters remain errors, and local calls report literals, typed values, or parsed local results passed back through the guard
- #17: dictionary types used solely as generic constraints are no longer reported
- #18: finite `Record` key sets are no longer classified as open dictionaries
- #24: empty and whitespace-only safety markers no longer satisfy the rule
- #26: parameter diagnostics show only the local binding
- #27: safety comments attached above `export const` declarations are recognized
- #29: aliases whose unions resolve to `unknown` are reported
- #30: parameters whose unions resolve to `unknown` are reported, preserving the `cause` and type-predicate exemptions

## Verification

- `pnpm check`

Closes #15
Closes #17
Closes #18
Closes #24
Closes #26
Closes #27
Closes #29
Closes #30
