### PR TITLE
docs: refresh README for current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Opinionated Oxlint rules that reject low-evidence and low-signal TypeScript and JavaScript patterns.
 
-This project is meant to be vendored, not treated as a fixed npm dependency. Copy the rules into your repository, read them, and change them to match your team's standards. The bundled agent skill handles the initial copy and configuration; after that, the vendored files are yours to maintain and make your own.
+Anti-slop is first and foremost the ruleset I use with my team. It reflects my preferences and taste rather than attempting to be a universal coding standard.
+
+This project is meant to be vendored, not treated as a fixed npm dependency. There is no official npm package. Copy the rules into your repository, read them, and change them to match your team's standards. The bundled agent skill handles the initial copy and configuration; after that, the vendored files are yours to maintain and make your own. Community-maintained forks and packages are welcome, but their compatibility and release lifecycle belong to their maintainers.
 
 ## Install with an agent skill
 
@@ -12,7 +14,7 @@ This project is meant to be vendored, not treated as a fixed npm dependency. Cop
 npx skills add dmmulroy/anti-slop --skill install-anti-slop
 ```
 
-Then ask your coding agent to install or configure anti-slop in the current repository. The skill copies the plugin, installs current Oxlint dependencies, merges the plugin into the existing lint configuration, enables every generic rule, and validates the result. In repositories that depend on Effect, it also enables the opt-in Effect rule group.
+Then ask your coding agent to install or configure anti-slop in the current repository. The skill copies the plugin, installs compatible Oxlint dependencies—matching an existing Oxlint version when present—merges the plugin into the existing lint configuration, enables every generic rule, and validates the result. In repositories that depend directly on Effect, it also enables the opt-in Effect rule group.
 
 To inspect available skills first:
 
@@ -22,7 +24,7 @@ npx skills add dmmulroy/anti-slop --list
 
 ## Manual local installation
 
-Copy `src/` into the target repository, for example at `tools/oxlint/anti-slop/`, and install matching current versions of `oxlint` and `@oxlint/plugins`.
+Copy `src/` into the target repository, for example at `tools/oxlint/anti-slop/`. If the repository already uses `oxlint`, install `@oxlint/plugins` at exactly the resolved Oxlint version. Otherwise, install the same current version of both packages. Keep both versions exact so upgrades move them together.
 
 Register the copied entry point in `oxlint.config.ts`:
 
@@ -92,25 +94,29 @@ export default defineConfig({
 
 ### Generic rules
 
-- `no-chained-type-assertions` — rejects nested type assertions that fabricate evidence.
-- `no-conditional-empty-object-spread` — rejects conditional spreads that use `{}` to omit fields.
-- `no-known-value-widening` — rejects explicit broad target types that discard known value evidence, including known arguments passed to local `unknown` type predicates.
-- `no-module-mocking` — rejects Vitest and Jest module mocks in favor of real dependency seams.
-- `no-object-parameters` — rejects the broad `object` type on function inputs.
-- `no-reflect-apply` — rejects `Reflect.apply` in favor of typed function calls.
-- `no-reflect-get` — rejects `Reflect.get` in favor of typed property access or boundary parsing.
-- `no-runtime-typeof` — requires boundary parsing instead of ad hoc `typeof` narrowing.
-- `no-shape-in-symbol-names` — rejects `shape` in symbol names.
-- `no-unknown-parameters` — rejects `unknown` inputs except the explicit `cause` convention and the subject of a type predicate.
-- `no-unknown-returns` — rejects function contracts that return `unknown` or `Promise<unknown>`.
-- `no-unknown-type-aliases` — rejects aliases that merely conceal `unknown`.
-- `no-unsafe-dictionary-type` — rejects dictionary value contracts based on `unknown`, `any`, `object`, `{}`, and semantic equivalents.
-- `no-widen-then-assert` — rejects local flows that widen known values and later assert them back.
-- `require-safety-comment-for-type-assertion` — requires each non-const assertion to document its checked invariant.
+- `no-chained-type-assertions` — rejects nested `as` and angle-bracket assertions that fabricate evidence; chains made only of `as const` remain valid.
+- `no-conditional-empty-object-spread` — reports object spreads that use a conditional `{}` branch to omit fields. It intentionally has no autofix because omission is not equivalent to assigning `undefined`.
+- `no-known-value-widening` — rejects known expressions flowing into explicit `unknown`, `object`, anonymous-object, or open-dictionary targets, including known arguments passed to local `unknown` type predicates. Empty dictionary accumulators and finite-key `Record` targets remain valid.
+- `no-module-mocking` — rejects Vitest and Jest `mock`, `doMock`, and `unstable_mockModule` calls in favor of real dependency seams.
+- `no-object-parameters` — rejects `object`, unions containing it, and scoped or transparent generic aliases that resolve to it on function inputs.
+- `no-reflect-apply` — rejects global `Reflect.apply` in favor of typed function calls.
+- `no-reflect-get` — rejects global `Reflect.get` in favor of typed property access or boundary parsing.
+- `no-runtime-typeof` — requires boundary parsing instead of ad hoc `typeof` narrowing. Existence probes against the string `"undefined"` are allowed, and type predicates can be enabled explicitly.
+- `no-shape-in-symbol-names` — rejects the case-insensitive substring `shape` in locally owned symbol names while allowing static member names such as Zod's `schema.shape` that cannot be renamed locally.
+- `no-unknown-parameters` — rejects `unknown` and unions containing it on function inputs except the explicit `cause` convention and the exact subject of a type predicate.
+- `no-unknown-returns` — rejects explicit function contracts that resolve to `unknown`, `Promise<unknown>`, or `PromiseLike<unknown>`, including scoped and transparent generic aliases.
+- `no-unknown-type-aliases` — rejects scoped and transparent generic aliases whose resolved type is `unknown`.
+- `no-unsafe-dictionary-type` — rejects dictionary value contracts based on `unknown`, `any`, `object`, `{}`, and semantic equivalents. Generic constraints such as `T extends Record<string, unknown>` are allowed.
+- `no-widen-then-assert` — rejects immutable local flows that widen known evidence to `unknown`, `any`, `object`, or a broad record and later assert it back to a narrower type.
+- `require-safety-comment-for-type-assertion` — requires each non-const assertion to have a nearby, non-empty invariant justification. Marker prefixes are configurable and default to `SAFETY`.
 
 ### Effect rules
 
-- `no-service-constructor-imports` — rejects relative project imports of exported `make<CapabilityName>` constructors outside `*.test.*` and `*.spec.*` files. Runtime callers should import the owning Layer and yield the contextual service instead. Package imports and static constructors such as `WorkspaceName.make` are outside the rule.
+- `no-service-constructor-imports` — rejects named `make<CapabilityName>` imports from relative project modules outside `*.test.*` and `*.spec.*` files. Runtime callers should import the owning Layer and yield the contextual service instead. Package and path-alias imports, default imports, and static constructors such as `WorkspaceName.make` are outside the rule.
+
+### Analysis boundaries
+
+The rules use Oxlint's ESTree and lexical-scope APIs rather than a TypeScript type checker. They resolve same-file aliases—including block-scoped aliases, forward references, and transparent generic aliases—but do not infer imported type definitions or cross-file call signatures. Rules that inspect calls therefore document when enforcement is intentionally local.
 
 ## Violation examples
 
@@ -268,7 +274,7 @@ Add a specific justification immediately before a necessary assertion:
 const userId = value as UserId;
 ```
 
-`SAFETY` remains the default marker. Repositories with an established convention can configure one or more alternatives; every marker must still be followed by a non-empty justification:
+`SAFETY` remains the default marker. Comments immediately above exported declarations are recognized. Repositories with an established convention can configure one or more alternatives; every marker must still be followed by a colon and a non-empty justification:
 
 ```json
 {
@@ -286,7 +292,7 @@ pnpm install
 pnpm check
 ```
 
-`src/` is canonical. After changing production source, run `pnpm sync:skill-assets`; CI checks that the skill's bundled copy remains identical.
+`src/` is canonical. After changing production source, run `pnpm sync:skill-assets`; CI checks that the skill's bundled copy remains identical. `pnpm check` runs Oxlint, every RuleTester suite, TypeScript typechecking, and the skill-asset drift check.
 
 ## License
 


### PR DESCRIPTION
## Summary

- state explicitly that anti-slop reflects the maintainer team's preferences, is intended for vendoring, and has no official npm package
- align agent and manual installation guidance with exact Oxlint / `@oxlint/plugins` version matching
- document all current rule semantics, exemptions, and configuration options introduced through `v0.1.1`
- clarify ESTree analysis boundaries and the Effect rule's intentionally unsupported import forms
- document custom safety markers, exported-declaration comments, and the complete `pnpm check` verification surface

## Audit

- all 15 generic rules are present in installation configuration, the rule catalog, and violation examples
- the optional Effect rule is present in configuration, the catalog, and examples
- both current rule option schemas are documented
- the skills.sh repository and badge URLs resolve

## Verification

- `pnpm check`
- README registry consistency check: 16 registered rules, 16 documented
