### PR TITLE
Customize anti-slop policy and ship JavaScript output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
-dist/
 .DS_Store
 *.log

--- a/dist/effect/index.d.ts
+++ b/dist/effect/index.d.ts
@@ -1,0 +1,3 @@
+/** Opt-in Oxlint rules for Effect service and Layer architecture. */
+declare const antiSlopEffectPlugin: import("@oxlint/plugins").Plugin;
+export default antiSlopEffectPlugin;

--- a/dist/effect/index.js
+++ b/dist/effect/index.js
@@ -1,0 +1,10 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+import { noServiceConstructorImportsRule } from "./rules/no-service-constructor-imports.js";
+/** Opt-in Oxlint rules for Effect service and Layer architecture. */
+const antiSlopEffectPlugin = eslintCompatPlugin({
+    meta: { name: "anti-slop-effect" },
+    rules: {
+        "no-service-constructor-imports": noServiceConstructorImportsRule,
+    },
+});
+export default antiSlopEffectPlugin;

--- a/dist/effect/rules/no-service-constructor-imports.d.ts
+++ b/dist/effect/rules/no-service-constructor-imports.d.ts
@@ -1,0 +1,2 @@
+/** Keep dependency-bearing Effect service constructors local to their owning capability modules. */
+export declare const noServiceConstructorImportsRule: import("@oxlint/plugins").Rule;

--- a/dist/effect/rules/no-service-constructor-imports.js
+++ b/dist/effect/rules/no-service-constructor-imports.js
@@ -1,0 +1,44 @@
+import { defineRule } from "@oxlint/plugins";
+const SERVICE_CONSTRUCTOR_NAME = /^make[A-Z]/u;
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/u;
+function isProjectLocalImport(source) {
+    return source.startsWith("./") || source.startsWith("../");
+}
+function getImportedName(specifier) {
+    if (specifier.imported.type === "Identifier")
+        return specifier.imported.name;
+    return specifier.imported.value;
+}
+/** Keep dependency-bearing Effect service constructors local to their owning capability modules. */
+export const noServiceConstructorImportsRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow project-local make<CapabilityName> imports outside test and spec files.",
+        },
+        messages: {
+            serviceConstructorImport: 'Do not import Effect service constructor "{{name}}" into runtime code. Import the owning Layer, yield the contextual service, and allow its requirements to propagate to the composition root.',
+        },
+    },
+    create(context) {
+        const isTestFile = TEST_FILE.test(context.filename.replaceAll("\\", "/"));
+        return {
+            ImportDeclaration(node) {
+                if (isTestFile || !isProjectLocalImport(node.source.value))
+                    return;
+                for (const specifier of node.specifiers) {
+                    if (specifier.type !== "ImportSpecifier")
+                        continue;
+                    const importedName = getImportedName(specifier);
+                    if (!SERVICE_CONSTRUCTOR_NAME.test(importedName))
+                        continue;
+                    context.report({
+                        node: specifier,
+                        messageId: "serviceConstructorImport",
+                        data: { name: importedName },
+                    });
+                }
+            },
+        };
+    },
+});

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,3 @@
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+declare const antiSlopPlugin: import("@oxlint/plugins").Plugin;
+export default antiSlopPlugin;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,38 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.js";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.js";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.js";
+import { noModuleMockingRule } from "./rules/no-module-mocking.js";
+import { noObjectParametersRule } from "./rules/no-object-parameters.js";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.js";
+import { noReflectGetRule } from "./rules/no-reflect-get.js";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.js";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.js";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.js";
+import { noUnknownReturnsRule } from "./rules/no-unknown-returns.js";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.js";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.js";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.js";
+import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.js";
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+    meta: { name: "anti-slop" },
+    rules: {
+        "no-chained-type-assertions": noChainedTypeAssertionsRule,
+        "no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+        "no-known-value-widening": noKnownValueWideningRule,
+        "no-module-mocking": noModuleMockingRule,
+        "no-object-parameters": noObjectParametersRule,
+        "no-reflect-apply": noReflectApplyRule,
+        "no-reflect-get": noReflectGetRule,
+        "no-runtime-typeof": noRuntimeTypeofRule,
+        "no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+        "no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+        "no-unknown-parameters": noUnknownParametersRule,
+        "no-unknown-returns": noUnknownReturnsRule,
+        "no-unknown-type-aliases": noUnknownTypeAliasesRule,
+        "no-widen-then-assert": noWidenThenAssertRule,
+        "require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
+    },
+});
+export default antiSlopPlugin;

--- a/dist/rules/no-chained-type-assertions.d.ts
+++ b/dist/rules/no-chained-type-assertions.d.ts
@@ -1,0 +1,2 @@
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export declare const noChainedTypeAssertionsRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-chained-type-assertions.js
+++ b/dist/rules/no-chained-type-assertions.js
@@ -1,0 +1,60 @@
+import { defineRule } from "@oxlint/plugins";
+function isTypeAssertionExpression(node) {
+    return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+function unwrapParenthesizedExpression(expression) {
+    let current = expression;
+    while (current.type === "ParenthesizedExpression") {
+        current = current.expression;
+    }
+    return current;
+}
+function isConstAssertion(node) {
+    const { typeAnnotation } = node;
+    return (typeAnnotation.type === "TSTypeReference" &&
+        typeAnnotation.typeName.type === "Identifier" &&
+        typeAnnotation.typeName.name === "const");
+}
+function isOutermostAssertionInChain(node) {
+    let current = node;
+    let parent = node.parent;
+    while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+        current = parent;
+        parent = parent.parent;
+    }
+    return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+function isForbiddenAssertionChain(node) {
+    let assertionCount = 0;
+    let hasNonConstAssertion = false;
+    let current = node;
+    while (isTypeAssertionExpression(current)) {
+        assertionCount += 1;
+        hasNonConstAssertion ||= !isConstAssertion(current);
+        current = unwrapParenthesizedExpression(current.expression);
+    }
+    return assertionCount > 1 && hasNonConstAssertion;
+}
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+        },
+        messages: {
+            chained: "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+        },
+    },
+    createOnce(context) {
+        const checkTypeAssertion = (node) => {
+            if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node))
+                return;
+            context.report({ node, messageId: "chained" });
+        };
+        return {
+            TSAsExpression: checkTypeAssertion,
+            TSTypeAssertion: checkTypeAssertion,
+        };
+    },
+});

--- a/dist/rules/no-conditional-empty-object-spread.d.ts
+++ b/dist/rules/no-conditional-empty-object-spread.d.ts
@@ -1,0 +1,2 @@
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export declare const noConditionalEmptyObjectSpreadRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-conditional-empty-object-spread.js
+++ b/dist/rules/no-conditional-empty-object-spread.js
@@ -1,0 +1,40 @@
+import { defineRule } from "@oxlint/plugins";
+function unwrapParentheses(node) {
+    let current = node;
+    while (current.type === "ParenthesizedExpression") {
+        current = current.expression;
+    }
+    return current;
+}
+function isEmptyObjectExpression(node) {
+    return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+function isConditionalEmptyObjectSpread(node) {
+    const conditional = unwrapParentheses(node);
+    return (conditional.type === "ConditionalExpression" &&
+        (isEmptyObjectExpression(conditional.consequent) ||
+            isEmptyObjectExpression(conditional.alternate)));
+}
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+    meta: {
+        type: "suggestion",
+        docs: {
+            description: "Disallow object spreads that conditionally spread an empty object to omit fields.",
+        },
+        messages: {
+            avoid: "This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.",
+        },
+    },
+    createOnce(context) {
+        return {
+            SpreadElement(node) {
+                if (node.parent.type !== "ObjectExpression")
+                    return;
+                if (isConditionalEmptyObjectSpread(node.argument)) {
+                    context.report({ node, messageId: "avoid" });
+                }
+            },
+        };
+    },
+});

--- a/dist/rules/no-known-value-widening.d.ts
+++ b/dist/rules/no-known-value-widening.d.ts
@@ -1,0 +1,2 @@
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export declare const noKnownValueWideningRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-known-value-widening.js
+++ b/dist/rules/no-known-value-widening.js
@@ -1,0 +1,309 @@
+import { defineRule } from "@oxlint/plugins";
+import { classifyUnsafeDictionaryValue, classifyWideningTarget, createTypeEnvironment, isKnownEvidenceExpression, } from "../shared/dictionary-types.js";
+import { containsUnknownType, functionParameterBindingName, functionParameterTypeAnnotation, } from "../shared/function-parameters.js";
+function unwrapExpression(expression) {
+    let current = expression;
+    while (current.type === "ParenthesizedExpression" ||
+        current.type === "TSAsExpression" ||
+        current.type === "TSSatisfiesExpression" ||
+        current.type === "TSTypeAssertion" ||
+        current.type === "TSNonNullExpression") {
+        current = current.expression;
+    }
+    return current;
+}
+function resolveVariable(sourceCode, identifier) {
+    let scope = sourceCode.getScope(identifier);
+    while (scope !== null) {
+        const variable = scope.set.get(identifier.name);
+        if (variable !== undefined)
+            return variable;
+        scope = scope.upper;
+    }
+    return null;
+}
+function variableDeclarator(variable) {
+    if (variable.defs.length !== 1)
+        return null;
+    const [definition] = variable.defs;
+    return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+        ? definition.node
+        : null;
+}
+function isStableConstVariable(variable, declarator) {
+    return (declarator.parent.type === "VariableDeclaration" &&
+        declarator.parent.kind === "const" &&
+        variable.references.every((reference) => reference.init || !reference.isWrite()));
+}
+function hasKnownEvidence(sourceCode, expression, visitedVariables = new Set()) {
+    if (isKnownEvidenceExpression(expression))
+        return true;
+    const unwrapped = unwrapExpression(expression);
+    if (unwrapped.type !== "Identifier")
+        return false;
+    const variable = resolveVariable(sourceCode, unwrapped);
+    if (variable === null || visitedVariables.has(variable))
+        return false;
+    const declarator = variableDeclarator(variable);
+    if (declarator === null ||
+        declarator.init === null ||
+        !isStableConstVariable(variable, declarator)) {
+        return false;
+    }
+    visitedVariables.add(variable);
+    return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+function isFunctionExpression(node) {
+    return (node.type === "ArrowFunctionExpression" ||
+        node.type === "FunctionDeclaration" ||
+        node.type === "FunctionExpression" ||
+        node.type === "TSDeclareFunction" ||
+        node.type === "TSEmptyBodyFunctionExpression");
+}
+function localFunctionForCall(sourceCode, callee) {
+    const unwrapped = unwrapExpression(callee);
+    if (isFunctionExpression(unwrapped))
+        return unwrapped;
+    if (unwrapped.type !== "Identifier")
+        return null;
+    const variable = resolveVariable(sourceCode, unwrapped);
+    if (variable === null || variable.defs.length !== 1)
+        return null;
+    const [definition] = variable.defs;
+    if (definition === undefined)
+        return null;
+    if (definition.type === "FunctionName" && isFunctionExpression(definition.node)) {
+        return definition.node;
+    }
+    if (definition.type !== "Variable" || definition.node.type !== "VariableDeclarator") {
+        return null;
+    }
+    const initializer = definition.node.init;
+    if (initializer === null)
+        return null;
+    const unwrappedInitializer = unwrapExpression(initializer);
+    return isFunctionExpression(unwrappedInitializer) ? unwrappedInitializer : null;
+}
+function variableTypeAnnotation(sourceCode, variable) {
+    if (variable.defs.length !== 1)
+        return null;
+    const [definition] = variable.defs;
+    if (definition === undefined)
+        return null;
+    if (definition.type === "Variable" &&
+        definition.node.type === "VariableDeclarator" &&
+        definition.node.id.type === "Identifier") {
+        return definition.node.id.typeAnnotation ?? null;
+    }
+    if (definition.type !== "Parameter" || !isFunctionExpression(definition.node)) {
+        return null;
+    }
+    const parameter = definition.node.params.find((candidate) => functionParameterBindingName(candidate, sourceCode) === variable.name);
+    return parameter === undefined ? null : (functionParameterTypeAnnotation(parameter) ?? null);
+}
+function hasInformativeType(type, environment) {
+    return classifyUnsafeDictionaryValue(type, environment) === null;
+}
+function hasKnownCallArgumentEvidence(sourceCode, expression, environment, visitedVariables = new Set()) {
+    if (expression.type === "ParenthesizedExpression" || expression.type === "TSNonNullExpression") {
+        return hasKnownCallArgumentEvidence(sourceCode, expression.expression, environment, visitedVariables);
+    }
+    if (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+        return hasInformativeType(expression.typeAnnotation, environment);
+    }
+    if (expression.type === "TSSatisfiesExpression") {
+        return hasKnownCallArgumentEvidence(sourceCode, expression.expression, environment, visitedVariables);
+    }
+    if (expression.type === "CallExpression") {
+        const owner = localFunctionForCall(sourceCode, expression.callee);
+        const returnType = owner?.returnType?.typeAnnotation;
+        return returnType !== undefined && hasInformativeType(returnType, environment);
+    }
+    if (expression.type !== "Identifier")
+        return isKnownEvidenceExpression(expression);
+    const variable = resolveVariable(sourceCode, expression);
+    if (variable === null || visitedVariables.has(variable))
+        return false;
+    const annotation = variableTypeAnnotation(sourceCode, variable);
+    if (annotation !== null) {
+        return hasInformativeType(annotation.typeAnnotation, environment);
+    }
+    const declarator = variableDeclarator(variable);
+    if (declarator === null ||
+        declarator.init === null ||
+        !isStableConstVariable(variable, declarator)) {
+        return false;
+    }
+    visitedVariables.add(variable);
+    return hasKnownCallArgumentEvidence(sourceCode, declarator.init, environment, visitedVariables);
+}
+function typePredicateSubjectIndex(sourceCode, owner) {
+    const predicate = owner.returnType?.typeAnnotation;
+    if (predicate?.type !== "TSTypePredicate" || predicate.parameterName.type !== "Identifier") {
+        return null;
+    }
+    const predicateParameterName = predicate.parameterName.name;
+    const index = owner.params.findIndex((parameter) => functionParameterBindingName(parameter, sourceCode) === predicateParameterName);
+    return index === -1 ? null : index;
+}
+function annotationTarget(annotation, environment) {
+    return annotation === null || annotation === undefined
+        ? null
+        : classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+function enclosingFunction(node) {
+    let current = node.parent;
+    while (current !== null && current.type !== "Program") {
+        if (current.type === "ArrowFunctionExpression" ||
+            current.type === "FunctionDeclaration" ||
+            current.type === "FunctionExpression") {
+            return current;
+        }
+        current = current.parent;
+    }
+    return null;
+}
+function sourceKeyName(sourceCode, key) {
+    if (key.type === "Identifier" || key.type === "PrivateIdentifier")
+        return key.name;
+    if (key.type === "Literal")
+        return String(key.value);
+    return sourceCode.getText(key);
+}
+function functionName(sourceCode, owner) {
+    if (owner === null)
+        return "anonymous function";
+    if (owner.id !== null)
+        return owner.id.name;
+    const parent = owner.parent;
+    if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+        return parent.id.name;
+    if (parent.type === "MethodDefinition")
+        return sourceKeyName(sourceCode, parent.key);
+    return "anonymous function";
+}
+function isEmptyObjectExpression(expression) {
+    const unwrapped = unwrapExpression(expression);
+    return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+function isDictionaryAccumulatorTarget(destination) {
+    return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+function hasParentAssertion(node) {
+    return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+        },
+        messages: {
+            widening: "The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.",
+        },
+    },
+    createOnce(context) {
+        let environment = null;
+        const reportFlow = (expression, destination, subject) => {
+            if (destination === null)
+                return;
+            if (isDictionaryAccumulatorTarget(destination) &&
+                isEmptyObjectExpression(expression)) {
+                return;
+            }
+            if (!hasKnownEvidence(context.sourceCode, expression))
+                return;
+            context.report({
+                node: expression,
+                messageId: "widening",
+                data: { subject, target: destination.kind },
+            });
+        };
+        const targetFromAnnotation = (annotation) => environment === null ? null : annotationTarget(annotation, environment);
+        return {
+            Program(node) {
+                environment = createTypeEnvironment(node, context.sourceCode.visitorKeys);
+            },
+            VariableDeclarator(node) {
+                if (node.init === null || node.id.type !== "Identifier")
+                    return;
+                reportFlow(node.init, targetFromAnnotation(node.id.typeAnnotation), `binding \`${node.id.name}\``);
+            },
+            PropertyDefinition(node) {
+                if (node.value === null)
+                    return;
+                reportFlow(node.value, targetFromAnnotation(node.typeAnnotation), `property \`${sourceKeyName(context.sourceCode, node.key)}\``);
+            },
+            AccessorProperty(node) {
+                if (node.value === null)
+                    return;
+                reportFlow(node.value, targetFromAnnotation(node.typeAnnotation), `property \`${sourceKeyName(context.sourceCode, node.key)}\``);
+            },
+            AssignmentExpression(node) {
+                if (node.operator !== "=" || node.left.type !== "Identifier")
+                    return;
+                const variable = resolveVariable(context.sourceCode, node.left);
+                if (variable === null)
+                    return;
+                const declarator = variableDeclarator(variable);
+                if (declarator === null || declarator.id.type !== "Identifier")
+                    return;
+                reportFlow(node.right, targetFromAnnotation(declarator.id.typeAnnotation), `binding \`${declarator.id.name}\``);
+            },
+            CallExpression(node) {
+                if (environment === null)
+                    return;
+                const owner = localFunctionForCall(context.sourceCode, node.callee);
+                if (owner === null)
+                    return;
+                const parameterIndex = typePredicateSubjectIndex(context.sourceCode, owner);
+                if (parameterIndex === null)
+                    return;
+                const parameter = owner.params[parameterIndex];
+                const argument = node.arguments[parameterIndex];
+                if (parameter === undefined || argument === undefined || argument.type === "SpreadElement") {
+                    return;
+                }
+                const parameterAnnotation = functionParameterTypeAnnotation(parameter);
+                if (parameterAnnotation === null ||
+                    parameterAnnotation === undefined ||
+                    !containsUnknownType(parameterAnnotation.typeAnnotation)) {
+                    return;
+                }
+                if (!hasKnownCallArgumentEvidence(context.sourceCode, argument, environment)) {
+                    return;
+                }
+                context.report({
+                    node: argument,
+                    messageId: "widening",
+                    data: {
+                        subject: `argument for parameter \`${functionParameterBindingName(parameter, context.sourceCode)}\` of \`${functionName(context.sourceCode, owner)}\``,
+                        target: "unknown",
+                    },
+                });
+            },
+            ReturnStatement(node) {
+                if (node.argument === null)
+                    return;
+                const owner = enclosingFunction(node);
+                reportFlow(node.argument, targetFromAnnotation(owner?.returnType), `return value of \`${functionName(context.sourceCode, owner)}\``);
+            },
+            ArrowFunctionExpression(node) {
+                if (node.body.type === "BlockStatement")
+                    return;
+                reportFlow(node.body, targetFromAnnotation(node.returnType), `return value of \`${functionName(context.sourceCode, node)}\``);
+            },
+            TSAsExpression(node) {
+                if (environment === null || hasParentAssertion(node))
+                    return;
+                reportFlow(node.expression, classifyWideningTarget(node.typeAnnotation, environment), "assertion");
+            },
+            TSTypeAssertion(node) {
+                if (environment === null || hasParentAssertion(node))
+                    return;
+                reportFlow(node.expression, classifyWideningTarget(node.typeAnnotation, environment), "assertion");
+            },
+        };
+    },
+});

--- a/dist/rules/no-module-mocking.d.ts
+++ b/dist/rules/no-module-mocking.d.ts
@@ -1,0 +1,2 @@
+/** Ban test framework module mocking in favor of real dependency seams. */
+export declare const noModuleMockingRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-module-mocking.js
+++ b/dist/rules/no-module-mocking.js
@@ -1,0 +1,78 @@
+import { defineRule } from "@oxlint/plugins";
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+function resolveVariable(sourceCode, identifier) {
+    let scope = sourceCode.getScope(identifier);
+    while (scope !== null) {
+        const variable = scope.set.get(identifier.name);
+        if (variable !== undefined)
+            return variable;
+        scope = scope.upper;
+    }
+    return null;
+}
+function importedName(node) {
+    if (node.type !== "ImportSpecifier")
+        return null;
+    return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+function isTestFrameworkObject(sourceCode, expression) {
+    if (expression.type !== "Identifier")
+        return false;
+    if ((expression.name === "vi" || expression.name === "jest") &&
+        sourceCode.isGlobalReference(expression)) {
+        return true;
+    }
+    const variable = resolveVariable(sourceCode, expression);
+    if (variable === null || variable.defs.length === 0) {
+        return expression.name === "vi" || expression.name === "jest";
+    }
+    return variable.defs.some((definition) => {
+        if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+            return false;
+        }
+        const source = definition.parent.source.value;
+        const name = importedName(definition.node);
+        return (source === "vitest" && name === "vi") || (source === "@jest/globals" && name === "jest");
+    });
+}
+function moduleMockCall(sourceCode, callee) {
+    if (!("property" in callee) || !("object" in callee) || !("computed" in callee))
+        return false;
+    if (!isTestFrameworkObject(sourceCode, callee.object))
+        return false;
+    const property = callee.property;
+    const method = callee.computed
+        ? property.type === "Literal" &&
+            (property.value === "doMock" ||
+                property.value === "mock" ||
+                property.value === "unstable_mockModule")
+            ? property.value
+            : null
+        : property.type === "Identifier"
+            ? property.name
+            : null;
+    return method !== null && moduleMockMethods.has(method);
+}
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+        },
+        messages: {
+            moduleMock: "Replace module mocking with dependency injection through a real seam. If this test covers a composition root, module imports are the dependency graph under test; document that boundary and disable this rule for the file with `/* oxlint-disable anti-slop/no-module-mocking */`.",
+        },
+    },
+    createOnce(context) {
+        return {
+            CallExpression(node) {
+                if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression")
+                    return;
+                if (moduleMockCall(context.sourceCode, node.callee)) {
+                    context.report({ node, messageId: "moduleMock" });
+                }
+            },
+        };
+    },
+});

--- a/dist/rules/no-object-parameters.d.ts
+++ b/dist/rules/no-object-parameters.d.ts
@@ -1,0 +1,2 @@
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export declare const noObjectParametersRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-object-parameters.js
+++ b/dist/rules/no-object-parameters.js
@@ -1,0 +1,56 @@
+import { defineRule } from "@oxlint/plugins";
+import { functionParameterBindingName, functionParameterTypeAnnotation, } from "../shared/function-parameters.js";
+import { createTypeAliasEnvironment, resolvedTypeMatches, } from "../shared/type-alias-resolution.js";
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+        },
+        messages: {
+            objectParameter: "Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.",
+        },
+    },
+    createOnce(context) {
+        let environment = null;
+        const resolvesToObject = (type) => environment !== null &&
+            resolvedTypeMatches(type, environment, (resolved, matches) => {
+                if (resolved.type === "TSObjectKeyword")
+                    return true;
+                if (resolved.type === "TSParenthesizedType") {
+                    return matches(resolved.typeAnnotation);
+                }
+                return (resolved.type === "TSUnionType" && resolved.types.some(matches));
+            });
+        const checkParameters = (node) => {
+            for (const parameter of node.params) {
+                const annotation = functionParameterTypeAnnotation(parameter);
+                if (annotation === null || annotation === undefined)
+                    continue;
+                if (!resolvesToObject(annotation.typeAnnotation))
+                    continue;
+                context.report({
+                    node: annotation.typeAnnotation,
+                    messageId: "objectParameter",
+                    data: { parameter: functionParameterBindingName(parameter, context.sourceCode) },
+                });
+            }
+        };
+        return {
+            Program(node) {
+                environment = createTypeAliasEnvironment(node, context.sourceCode.visitorKeys);
+            },
+            ArrowFunctionExpression: checkParameters,
+            FunctionDeclaration: checkParameters,
+            FunctionExpression: checkParameters,
+            TSCallSignatureDeclaration: checkParameters,
+            TSConstructSignatureDeclaration: checkParameters,
+            TSConstructorType: checkParameters,
+            TSDeclareFunction: checkParameters,
+            TSEmptyBodyFunctionExpression: checkParameters,
+            TSFunctionType: checkParameters,
+            TSMethodSignature: checkParameters,
+        };
+    },
+});

--- a/dist/rules/no-reflect-apply.d.ts
+++ b/dist/rules/no-reflect-apply.d.ts
@@ -1,0 +1,2 @@
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export declare const noReflectApplyRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-reflect-apply.js
+++ b/dist/rules/no-reflect-apply.js
@@ -1,0 +1,25 @@
+import { defineRule } from "@oxlint/plugins";
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.js";
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+        },
+        messages: {
+            reflectApply: "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+        },
+    },
+    createOnce(context) {
+        return {
+            CallExpression(node) {
+                if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression")
+                    return;
+                if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+                    context.report({ node, messageId: "reflectApply" });
+                }
+            },
+        };
+    },
+});

--- a/dist/rules/no-reflect-get.d.ts
+++ b/dist/rules/no-reflect-get.d.ts
@@ -1,0 +1,2 @@
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export declare const noReflectGetRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-reflect-get.js
+++ b/dist/rules/no-reflect-get.js
@@ -1,0 +1,25 @@
+import { defineRule } from "@oxlint/plugins";
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.js";
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+        },
+        messages: {
+            reflectGet: "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+        },
+    },
+    createOnce(context) {
+        return {
+            CallExpression(node) {
+                if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression")
+                    return;
+                if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+                    context.report({ node, messageId: "reflectGet" });
+                }
+            },
+        };
+    },
+});

--- a/dist/rules/no-runtime-typeof.d.ts
+++ b/dist/rules/no-runtime-typeof.d.ts
@@ -1,0 +1,2 @@
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export declare const noRuntimeTypeofRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-runtime-typeof.js
+++ b/dist/rules/no-runtime-typeof.js
@@ -1,0 +1,64 @@
+import { defineRule } from "@oxlint/plugins";
+function isRuntimeFunction(node) {
+    return (node.type === "ArrowFunctionExpression" ||
+        node.type === "FunctionDeclaration" ||
+        node.type === "FunctionExpression");
+}
+function isInsideTypeGuard(node) {
+    let current = node.parent;
+    while (current !== null && current.type !== "Program") {
+        if (isRuntimeFunction(current)) {
+            return current.returnType?.typeAnnotation.type === "TSTypePredicate";
+        }
+        current = current.parent;
+    }
+    return false;
+}
+/** Return whether typeof safely probes for the existence of a possibly absent binding. */
+function isExistenceProbe(node) {
+    const parent = node.parent;
+    if (parent.type !== "BinaryExpression")
+        return false;
+    if (!["===", "!==", "==", "!="].includes(parent.operator))
+        return false;
+    const other = parent.left === node ? parent.right : parent.left;
+    return other.type === "Literal" && other.value === "undefined";
+}
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+        },
+        messages: {
+            runtimeTypeof: "A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowInTypeGuards: { type: "boolean" },
+                },
+                additionalProperties: false,
+            },
+        ],
+        defaultOptions: [{ allowInTypeGuards: false }],
+    },
+    createOnce(context) {
+        return {
+            UnaryExpression(node) {
+                const option = context.options?.[0];
+                const allowInTypeGuards = typeof option === "object" &&
+                    option !== null &&
+                    !Array.isArray(option) &&
+                    option.allowInTypeGuards === true;
+                if (node.operator === "typeof" &&
+                    !isExistenceProbe(node) &&
+                    (!allowInTypeGuards || !isInsideTypeGuard(node))) {
+                    context.report({ node, messageId: "runtimeTypeof" });
+                }
+            },
+        };
+    },
+});

--- a/dist/rules/no-shape-in-symbol-names.d.ts
+++ b/dist/rules/no-shape-in-symbol-names.d.ts
@@ -1,0 +1,2 @@
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export declare const noForbiddenTermInSymbolNamesRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-shape-in-symbol-names.js
+++ b/dist/rules/no-shape-in-symbol-names.js
@@ -1,0 +1,40 @@
+import { defineRule } from "@oxlint/plugins";
+const FORBIDDEN_SYMBOL_NAME = "shape";
+function containsForbiddenSymbolName(name) {
+    return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+/** Return whether an identifier names a statically accessed member owned by another value. */
+function isBorrowedMemberName(node) {
+    const parent = node.parent;
+    if (parent === null || parent.type !== "MemberExpression")
+        return false;
+    return parent.property === node && parent.computed === false;
+}
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: 'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+        },
+        messages: {
+            forbiddenSymbolName: 'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+        },
+    },
+    createOnce(context) {
+        const reportForbiddenSymbolName = (node) => {
+            if (!containsForbiddenSymbolName(node.name) || isBorrowedMemberName(node))
+                return;
+            context.report({
+                node,
+                messageId: "forbiddenSymbolName",
+                data: { name: node.name },
+            });
+        };
+        return {
+            Identifier: reportForbiddenSymbolName,
+            PrivateIdentifier: reportForbiddenSymbolName,
+            JSXIdentifier: reportForbiddenSymbolName,
+        };
+    },
+});

--- a/dist/rules/no-unknown-parameters.d.ts
+++ b/dist/rules/no-unknown-parameters.d.ts
@@ -1,0 +1,2 @@
+/** Disallow unknown inputs except explicitly named error handling and type predicates. */
+export declare const noUnknownParametersRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-unknown-parameters.js
+++ b/dist/rules/no-unknown-parameters.js
@@ -1,0 +1,53 @@
+import { defineRule } from "@oxlint/plugins";
+import { containsUnknownType, functionParameterBindingName, functionParameterTypeAnnotation, } from "../shared/function-parameters.js";
+// Allows conventional names only at explicit error-handling boundaries.
+const unknownErrorParameterNames = new Set(["cause", "error", "reason"]);
+function isTypePredicateSubject(owner, parameterName) {
+    const predicate = owner.returnType?.typeAnnotation;
+    return (predicate?.type === "TSTypePredicate" &&
+        predicate.parameterName.type === "Identifier" &&
+        predicate.parameterName.name === parameterName);
+}
+/** Disallow unknown inputs except explicitly named error handling and type predicates. */
+export const noUnknownParametersRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow explicitly unknown function parameters except conventional error parameters and type-predicate subjects; decode unknown input at its I/O boundary instead.",
+        },
+        messages: {
+            unknownParameter: "Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.",
+        },
+    },
+    createOnce(context) {
+        const checkParameters = (node) => {
+            for (const parameter of node.params) {
+                const annotation = functionParameterTypeAnnotation(parameter);
+                if (annotation === null || annotation === undefined)
+                    continue;
+                if (!containsUnknownType(annotation.typeAnnotation))
+                    continue;
+                const name = functionParameterBindingName(parameter, context.sourceCode);
+                if (unknownErrorParameterNames.has(name) || isTypePredicateSubject(node, name))
+                    continue;
+                context.report({
+                    node: annotation.typeAnnotation,
+                    messageId: "unknownParameter",
+                    data: { parameter: name },
+                });
+            }
+        };
+        return {
+            ArrowFunctionExpression: checkParameters,
+            FunctionDeclaration: checkParameters,
+            FunctionExpression: checkParameters,
+            TSCallSignatureDeclaration: checkParameters,
+            TSConstructSignatureDeclaration: checkParameters,
+            TSConstructorType: checkParameters,
+            TSDeclareFunction: checkParameters,
+            TSEmptyBodyFunctionExpression: checkParameters,
+            TSFunctionType: checkParameters,
+            TSMethodSignature: checkParameters,
+        };
+    },
+});

--- a/dist/rules/no-unknown-returns.d.ts
+++ b/dist/rules/no-unknown-returns.d.ts
@@ -1,0 +1,2 @@
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export declare const noUnknownReturnsRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-unknown-returns.js
+++ b/dist/rules/no-unknown-returns.js
@@ -1,0 +1,58 @@
+import { defineRule } from "@oxlint/plugins";
+import { createTypeAliasEnvironment, resolvedTypeMatches, } from "../shared/type-alias-resolution.js";
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow functions whose explicit return contract is unknown or Promise<unknown>.",
+        },
+        messages: {
+            unknownReturn: "This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.",
+        },
+    },
+    createOnce(context) {
+        let environment = null;
+        const resolvesToUnknown = (type) => environment !== null &&
+            resolvedTypeMatches(type, environment, (resolved, matches) => {
+                if (resolved.type === "TSUnknownKeyword")
+                    return true;
+                if (resolved.type === "TSParenthesizedType") {
+                    return matches(resolved.typeAnnotation);
+                }
+                if (resolved.type === "TSUnionType")
+                    return resolved.types.some(matches);
+                if (resolved.type !== "TSTypeReference" ||
+                    resolved.typeName.type !== "Identifier" ||
+                    (resolved.typeName.name !== "Promise" &&
+                        resolved.typeName.name !== "PromiseLike")) {
+                    return false;
+                }
+                const value = resolved.typeArguments?.params[0];
+                return value !== undefined && matches(value);
+            });
+        const checkReturnType = (node) => {
+            const annotation = node.returnType;
+            if (annotation === null || annotation === undefined)
+                return;
+            if (!resolvesToUnknown(annotation.typeAnnotation))
+                return;
+            context.report({ node: annotation.typeAnnotation, messageId: "unknownReturn" });
+        };
+        return {
+            Program(node) {
+                environment = createTypeAliasEnvironment(node, context.sourceCode.visitorKeys);
+            },
+            ArrowFunctionExpression: checkReturnType,
+            FunctionDeclaration: checkReturnType,
+            FunctionExpression: checkReturnType,
+            TSCallSignatureDeclaration: checkReturnType,
+            TSConstructSignatureDeclaration: checkReturnType,
+            TSConstructorType: checkReturnType,
+            TSDeclareFunction: checkReturnType,
+            TSEmptyBodyFunctionExpression: checkReturnType,
+            TSFunctionType: checkReturnType,
+            TSMethodSignature: checkReturnType,
+        };
+    },
+});

--- a/dist/rules/no-unknown-type-aliases.d.ts
+++ b/dist/rules/no-unknown-type-aliases.d.ts
@@ -1,0 +1,2 @@
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export declare const noUnknownTypeAliasesRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-unknown-type-aliases.js
+++ b/dist/rules/no-unknown-type-aliases.js
@@ -1,0 +1,40 @@
+import { defineRule } from "@oxlint/plugins";
+import { createTypeAliasEnvironment, resolvedTypeMatches, } from "../shared/type-alias-resolution.js";
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+        },
+        messages: {
+            unknownAlias: "Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+        },
+    },
+    createOnce(context) {
+        let environment = null;
+        const resolvesToUnknown = (type) => environment !== null &&
+            resolvedTypeMatches(type, environment, (resolved, matches) => {
+                if (resolved.type === "TSUnknownKeyword")
+                    return true;
+                if (resolved.type === "TSParenthesizedType") {
+                    return matches(resolved.typeAnnotation);
+                }
+                return resolved.type === "TSUnionType" && resolved.types.some(matches);
+            });
+        return {
+            Program(node) {
+                environment = createTypeAliasEnvironment(node, context.sourceCode.visitorKeys);
+            },
+            TSTypeAliasDeclaration(node) {
+                if (!resolvesToUnknown(node.typeAnnotation))
+                    return;
+                context.report({
+                    node: node.id,
+                    messageId: "unknownAlias",
+                    data: { alias: node.id.name },
+                });
+            },
+        };
+    },
+});

--- a/dist/rules/no-unsafe-dictionary-type.d.ts
+++ b/dist/rules/no-unsafe-dictionary-type.d.ts
@@ -1,0 +1,2 @@
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export declare const noUnsafeDictionaryTypeRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-unsafe-dictionary-type.js
+++ b/dist/rules/no-unsafe-dictionary-type.js
@@ -1,0 +1,134 @@
+import { defineRule } from "@oxlint/plugins";
+import { classifyUnsafeDictionary, classifyUnsafeDictionaryValue, createTypeEnvironment, } from "../shared/dictionary-types.js";
+import { visibleTypeAlias } from "../shared/type-alias-resolution.js";
+const typeNodeKinds = new Set([
+    "JSDocNonNullableType",
+    "JSDocNullableType",
+    "JSDocUnknownType",
+    "TSAnyKeyword",
+    "TSArrayType",
+    "TSBigIntKeyword",
+    "TSBooleanKeyword",
+    "TSConditionalType",
+    "TSConstructorType",
+    "TSFunctionType",
+    "TSImportType",
+    "TSIndexedAccessType",
+    "TSInferType",
+    "TSIntersectionType",
+    "TSIntrinsicKeyword",
+    "TSLiteralType",
+    "TSMappedType",
+    "TSNamedTupleMember",
+    "TSNeverKeyword",
+    "TSNullKeyword",
+    "TSNumberKeyword",
+    "TSObjectKeyword",
+    "TSParenthesizedType",
+    "TSStringKeyword",
+    "TSSymbolKeyword",
+    "TSTemplateLiteralType",
+    "TSThisType",
+    "TSTupleType",
+    "TSTypeLiteral",
+    "TSTypeOperator",
+    "TSTypePredicate",
+    "TSTypeQuery",
+    "TSTypeReference",
+    "TSUndefinedKeyword",
+    "TSUnionType",
+    "TSUnknownKeyword",
+    "TSVoidKeyword",
+]);
+function isTypeNode(node) {
+    return typeNodeKinds.has(node.type);
+}
+function typeReferenceName(type) {
+    return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+function isInsideTypeAliasDeclaration(node) {
+    let current = node.parent;
+    while (current !== null && current.type !== "Program") {
+        if (current.type === "TSTypeAliasDeclaration")
+            return true;
+        current = current.parent;
+    }
+    return false;
+}
+function isPlainAliasConsumerUse(node, environment) {
+    if (node.type !== "TSTypeReference" || node.typeArguments?.params.length)
+        return false;
+    const name = typeReferenceName(node);
+    return (name !== null &&
+        visibleTypeAlias(name, node, environment.typeAliases) !== null &&
+        !isInsideTypeAliasDeclaration(node));
+}
+function isInsideTypeParameterConstraint(node) {
+    let child = node;
+    let parent = child.parent;
+    while (parent !== null && parent.type !== "Program") {
+        if (parent.type === "TSTypeParameter" && parent.constraint === child)
+            return true;
+        child = parent;
+        parent = child.parent;
+    }
+    return false;
+}
+function shouldReportType(node, environment) {
+    if (isInsideTypeParameterConstraint(node))
+        return false;
+    if (isPlainAliasConsumerUse(node, environment))
+        return false;
+    if (classifyUnsafeDictionary(node, environment) === null)
+        return false;
+    let current = node.parent;
+    while (current !== null && current.type !== "Program") {
+        if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+            return false;
+        current = current.parent;
+    }
+    return true;
+}
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+        },
+        messages: {
+            unsafeDictionary: "This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+        },
+    },
+    createOnce(context) {
+        let environment = null;
+        const report = (node, value) => {
+            context.report({ node, messageId: "unsafeDictionary", data: { value } });
+        };
+        const reportIfUnsafe = (node) => {
+            if (environment === null || !shouldReportType(node, environment))
+                return;
+            const unsafe = classifyUnsafeDictionary(node, environment);
+            if (unsafe === null)
+                return;
+            report(node, unsafe.unsafeValue);
+        };
+        return {
+            Program(node) {
+                environment = createTypeEnvironment(node, context.sourceCode.visitorKeys);
+            },
+            TSTypeReference: reportIfUnsafe,
+            TSTypeLiteral: reportIfUnsafe,
+            TSMappedType: reportIfUnsafe,
+            TSIndexSignature(node) {
+                if (environment === null ||
+                    node.typeAnnotation === null ||
+                    node.parent.type === "TSTypeLiteral")
+                    return;
+                const unsafe = classifyUnsafeDictionaryValue(node.typeAnnotation.typeAnnotation, environment);
+                if (unsafe !== null)
+                    report(node, unsafe.unsafeValue);
+            },
+        };
+    },
+});

--- a/dist/rules/no-widen-then-assert.d.ts
+++ b/dist/rules/no-widen-then-assert.d.ts
@@ -1,0 +1,2 @@
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export declare const noWidenThenAssertRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/no-widen-then-assert.js
+++ b/dist/rules/no-widen-then-assert.js
@@ -1,0 +1,270 @@
+import { defineRule } from "@oxlint/plugins";
+const functionBoundaryTypes = new Set([
+    "ArrowFunctionExpression",
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "TSDeclareFunction",
+    "TSEmptyBodyFunctionExpression",
+]);
+function unwrapExpressionParentheses(expression) {
+    let current = expression;
+    while (current.type === "ParenthesizedExpression")
+        current = current.expression;
+    return current;
+}
+function unwrapTypeParentheses(type) {
+    let current = type;
+    while (current.type === "TSParenthesizedType")
+        current = current.typeAnnotation;
+    return current;
+}
+function typeReferenceName(type) {
+    return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+function isUnknownOrAnyType(type) {
+    const unwrapped = unwrapTypeParentheses(type);
+    return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+function isBroadRecordKeyType(type) {
+    const unwrapped = unwrapTypeParentheses(type);
+    if (unwrapped.type === "TSStringKeyword" ||
+        unwrapped.type === "TSNumberKeyword" ||
+        unwrapped.type === "TSSymbolKeyword") {
+        return true;
+    }
+    if (unwrapped.type === "TSUnionType")
+        return unwrapped.types.every(isBroadRecordKeyType);
+    return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+function isBroadRecordType(type) {
+    const unwrapped = unwrapTypeParentheses(type);
+    if (unwrapped.type === "TSTypeReference") {
+        if (typeReferenceName(unwrapped) === "Readonly") {
+            const [inner] = unwrapped.typeArguments?.params ?? [];
+            return inner !== undefined && isBroadRecordType(inner);
+        }
+        if (typeReferenceName(unwrapped) !== "Record")
+            return false;
+        const parameters = unwrapped.typeArguments?.params ?? [];
+        return (parameters.length === 2 &&
+            parameters[0] !== undefined &&
+            parameters[1] !== undefined &&
+            isBroadRecordKeyType(parameters[0]) &&
+            isUnknownOrAnyType(parameters[1]));
+    }
+    if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1)
+        return false;
+    const [member] = unwrapped.members;
+    const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+    return (member?.type === "TSIndexSignature" &&
+        member.parameters.length === 1 &&
+        parameter !== undefined &&
+        isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+        isUnknownOrAnyType(member.typeAnnotation.typeAnnotation));
+}
+function broadTypeKind(type) {
+    const unwrapped = unwrapTypeParentheses(type);
+    if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword")
+        return "top";
+    if (unwrapped.type === "TSObjectKeyword")
+        return "object";
+    return isBroadRecordType(unwrapped) ? "record" : null;
+}
+function assertedExpression(node) {
+    return unwrapExpressionParentheses(node.expression);
+}
+function assertionFromExpression(expression) {
+    const unwrapped = unwrapExpressionParentheses(expression);
+    return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+        ? unwrapped
+        : null;
+}
+function normalizedTypeText(sourceText, type) {
+    return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+function typesHaveSameSyntax(sourceText, left, right) {
+    return (left !== null &&
+        normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+            normalizedTypeText(sourceText, unwrapTypeParentheses(right)));
+}
+function isDefinitelyObjectType(type) {
+    const unwrapped = unwrapTypeParentheses(type);
+    switch (unwrapped.type) {
+        case "TSArrayType":
+        case "TSConstructorType":
+        case "TSFunctionType":
+        case "TSMappedType":
+        case "TSObjectKeyword":
+        case "TSTupleType":
+            return true;
+        case "TSTypeLiteral":
+            return unwrapped.members.length > 0;
+        case "TSIntersectionType":
+            return unwrapped.types.every(isDefinitelyObjectType);
+        case "TSTypeOperator":
+            return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+        default:
+            return false;
+    }
+}
+function isDefinitelyNarrowerRecordType(type) {
+    const unwrapped = unwrapTypeParentheses(type);
+    if (unwrapped.type === "TSTypeLiteral") {
+        return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+    }
+    if (unwrapped.type !== "TSTypeReference")
+        return false;
+    if (typeReferenceName(unwrapped) === "Readonly") {
+        const [inner] = unwrapped.typeArguments?.params ?? [];
+        return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+    }
+    if (typeReferenceName(unwrapped) !== "Record")
+        return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1]));
+}
+function functionBoundary(node) {
+    let current = node.parent;
+    while (current !== null && current.type !== "Program") {
+        if (functionBoundaryTypes.has(current.type))
+            return current;
+        current = current.parent;
+    }
+    return null;
+}
+function resolvedVariableForIdentifier(scopes, identifier) {
+    for (const scope of scopes) {
+        const reference = scope.references.find((candidate) => candidate.identifier.start === identifier.start &&
+            candidate.identifier.end === identifier.end);
+        if (reference !== undefined)
+            return reference.resolved;
+    }
+    return null;
+}
+function variableDeclarator(variable) {
+    for (const definition of variable.defs) {
+        if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+            return definition.node;
+        }
+    }
+    return null;
+}
+function knownValueEvidence(expression, scopes, boundary, visitedVariables) {
+    const unwrapped = unwrapExpressionParentheses(expression);
+    if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+        if (broadTypeKind(unwrapped.typeAnnotation) !== null)
+            return null;
+        return { type: unwrapped.typeAnnotation };
+    }
+    if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+        return { type: null };
+    }
+    if (unwrapped.type === "ArrayExpression" ||
+        unwrapped.type === "ArrowFunctionExpression" ||
+        unwrapped.type === "ClassExpression" ||
+        unwrapped.type === "FunctionExpression" ||
+        unwrapped.type === "NewExpression" ||
+        unwrapped.type === "ObjectExpression") {
+        return { type: null };
+    }
+    if (unwrapped.type !== "Identifier")
+        return null;
+    const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+    if (variable === null || visitedVariables.has(variable))
+        return null;
+    const annotatedIdentifier = variable.identifiers.find((identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined);
+    const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+    if (annotation !== undefined && annotatedIdentifier !== undefined) {
+        if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+            return null;
+        }
+        return { type: annotation };
+    }
+    const declarator = variableDeclarator(variable);
+    if (declarator === null ||
+        declarator.parent.type !== "VariableDeclaration" ||
+        declarator.parent.kind !== "const" ||
+        declarator.init === null ||
+        variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+        functionBoundary(declarator) !== boundary) {
+        return null;
+    }
+    return knownValueEvidence(declarator.init, scopes, boundary, new Set([...visitedVariables, variable]));
+}
+function widenedBinding(variable, scopes) {
+    const declarator = variableDeclarator(variable);
+    if (declarator === null ||
+        declarator.parent.type !== "VariableDeclaration" ||
+        declarator.parent.kind !== "const" ||
+        declarator.id.type !== "Identifier" ||
+        declarator.init === null ||
+        variable.references.some((reference) => reference.isWrite() && !reference.init)) {
+        return null;
+    }
+    const boundary = functionBoundary(declarator);
+    const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+    const initializerAssertion = assertionFromExpression(declarator.init);
+    const initializerBroadKind = initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+    const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+    const broadKind = declaredBroadKind ?? initializerBroadKind;
+    if (broadKind === null)
+        return null;
+    const originalExpression = initializerAssertion !== null && initializerBroadKind !== null
+        ? assertedExpression(initializerAssertion)
+        : declarator.init;
+    const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+    return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+function assertionIsNarrower(sourceText, broadKind, evidence, assertedType) {
+    if (broadTypeKind(assertedType) !== null)
+        return false;
+    if (broadKind === "top")
+        return true;
+    if (typesHaveSameSyntax(sourceText, evidence.type, assertedType))
+        return true;
+    if (broadKind === "object")
+        return isDefinitelyObjectType(assertedType);
+    return isDefinitelyNarrowerRecordType(assertedType);
+}
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+        },
+        messages: {
+            widenThenAssert: 'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+        },
+    },
+    createOnce(context) {
+        let scopes = [];
+        const checkAssertion = (node) => {
+            const expression = assertedExpression(node);
+            if (expression.type !== "Identifier")
+                return;
+            const variable = resolvedVariableForIdentifier(scopes, expression);
+            if (variable === null)
+                return;
+            const widened = widenedBinding(variable, scopes);
+            if (widened === null ||
+                node.start <= widened.declaredAt ||
+                functionBoundary(node) !== widened.boundary ||
+                !assertionIsNarrower(context.sourceCode.text, widened.broadKind, widened.evidence, node.typeAnnotation)) {
+                return;
+            }
+            context.report({
+                node,
+                messageId: "widenThenAssert",
+                data: { name: expression.name },
+            });
+        };
+        return {
+            Program() {
+                scopes = context.sourceCode.scopeManager.scopes;
+            },
+            TSAsExpression: checkAssertion,
+            TSTypeAssertion: checkAssertion,
+        };
+    },
+});

--- a/dist/rules/require-safety-comment-for-type-assertion.d.ts
+++ b/dist/rules/require-safety-comment-for-type-assertion.d.ts
@@ -1,0 +1,2 @@
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export declare const requireSafetyCommentForTypeAssertionRule: import("@oxlint/plugins").Rule;

--- a/dist/rules/require-safety-comment-for-type-assertion.js
+++ b/dist/rules/require-safety-comment-for-type-assertion.js
@@ -1,0 +1,100 @@
+import { defineRule } from "@oxlint/plugins";
+const DEFAULT_SAFETY_MARKERS = ["SAFETY"];
+const commentOwnerKinds = new Set([
+    "ExpressionStatement",
+    "PropertyDefinition",
+    "ReturnStatement",
+    "ThrowStatement",
+    "VariableDeclaration",
+]);
+function isConstAssertion(node) {
+    return (node.typeAnnotation.type === "TSTypeReference" &&
+        node.typeAnnotation.typeName.type === "Identifier" &&
+        node.typeAnnotation.typeName.name === "const");
+}
+function configuredSafetyMarkers(option) {
+    if (typeof option !== "object" || option === null || !("markers" in option)) {
+        return DEFAULT_SAFETY_MARKERS;
+    }
+    const configured = option.markers;
+    if (!Array.isArray(configured))
+        return DEFAULT_SAFETY_MARKERS;
+    const markers = configured.flatMap((marker) => typeof marker === "string" && marker.trim().length > 0 ? [marker.trim()] : []);
+    return markers.length > 0 ? markers : DEFAULT_SAFETY_MARKERS;
+}
+function markerPattern(markers) {
+    const alternation = markers
+        .map((marker) => marker.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw `\$&`))
+        .join("|");
+    return new RegExp(String.raw `(?:^|[^\p{L}\p{N}_])(?:${alternation})\s*:\s*\S`, "u");
+}
+function hasSafetyJustificationBefore(sourceCode, owner, assertion, pattern) {
+    return sourceCode
+        .getCommentsBefore(owner)
+        .some((comment) => comment.end <= assertion.start && pattern.test(comment.value));
+}
+function hasSafetyComment(sourceCode, node, pattern) {
+    let current = node;
+    while (true) {
+        if (hasSafetyJustificationBefore(sourceCode, current, node, pattern))
+            return true;
+        if (commentOwnerKinds.has(current.type)) {
+            const exportDeclaration = current.parent;
+            return (exportDeclaration.type === "ExportNamedDeclaration" &&
+                exportDeclaration.declaration === current &&
+                hasSafetyJustificationBefore(sourceCode, exportDeclaration, node, pattern));
+        }
+        if (current.parent.type === "Program")
+            return false;
+        current = current.parent;
+    }
+}
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+        },
+        messages: {
+            missingSafetyComment: "This type assertion has no `{{marker}}:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    markers: {
+                        type: "array",
+                        items: { type: "string", minLength: 1 },
+                        minItems: 1,
+                        uniqueItems: true,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        defaultOptions: [{ markers: ["SAFETY"] }],
+    },
+    createOnce(context) {
+        const patterns = new Map();
+        const checkAssertion = (node) => {
+            if (isConstAssertion(node))
+                return;
+            const markers = configuredSafetyMarkers(context.options?.[0]);
+            const patternKey = markers.join("\u0000");
+            const pattern = patterns.get(patternKey) ?? markerPattern(markers);
+            patterns.set(patternKey, pattern);
+            if (hasSafetyComment(context.sourceCode, node, pattern))
+                return;
+            context.report({
+                node,
+                messageId: "missingSafetyComment",
+                data: { marker: markers[0] ?? DEFAULT_SAFETY_MARKERS[0] },
+            });
+        };
+        return {
+            TSAsExpression: checkAssertion,
+            TSTypeAssertion: checkAssertion,
+        };
+    },
+});

--- a/dist/shared/dictionary-types.d.ts
+++ b/dist/shared/dictionary-types.d.ts
@@ -1,0 +1,20 @@
+import type { ESTree } from "@oxlint/plugins";
+import { type TypeAliasEnvironment as LexicalTypeAliasEnvironment } from "./type-alias-resolution.ts";
+export type UnsafeDictionary = {
+    readonly kind: "unsafe-dictionary";
+    readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+export type WideningTargetKind = "anonymous object" | "generic container" | "object" | "open dictionary" | "unknown";
+export type WideningTarget = {
+    readonly kind: WideningTargetKind;
+};
+export type TypeEnvironment = {
+    readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+    readonly typeAliases: LexicalTypeAliasEnvironment;
+};
+export declare function createTypeEnvironment(program: ESTree.Program, visitorKeys: Readonly<Record<string, readonly string[]>>): TypeEnvironment;
+export declare function classifyUnsafeDictionaryValue(valueType: ESTree.TSType, environment: TypeEnvironment): UnsafeDictionary | null;
+export declare function classifyUnsafeDictionary(type: ESTree.TSType, environment: TypeEnvironment): UnsafeDictionary | null;
+export declare function classifyWideningTarget(type: ESTree.TSType, environment: TypeEnvironment): WideningTarget | null;
+export declare function isPopulatedObjectExpression(expression: ESTree.Expression): boolean;
+export declare function isKnownEvidenceExpression(expression: ESTree.Expression): boolean;

--- a/dist/shared/dictionary-types.js
+++ b/dist/shared/dictionary-types.js
@@ -1,0 +1,377 @@
+import { createTypeAliasEnvironment, hasVisibleTypeBinding, visibleTypeAlias, } from "./type-alias-resolution.js";
+const BUILT_INS = new Set([
+    "Record",
+    "Readonly",
+    "Partial",
+    "Required",
+    "Pick",
+    "Omit",
+    "PropertyKey",
+    "NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+function declaredStatement(statement) {
+    return statement.type === "ExportNamedDeclaration" ||
+        statement.type === "ExportDefaultDeclaration"
+        ? (statement.declaration ?? null)
+        : statement;
+}
+export function createTypeEnvironment(program, visitorKeys) {
+    const interfaces = new Map();
+    for (const statement of program.body) {
+        const declaration = declaredStatement(statement);
+        if (declaration?.type !== "TSInterfaceDeclaration")
+            continue;
+        const declarations = interfaces.get(declaration.id.name) ?? [];
+        declarations.push(declaration);
+        interfaces.set(declaration.id.name, declarations);
+    }
+    return {
+        interfaces,
+        typeAliases: createTypeAliasEnvironment(program, visitorKeys),
+    };
+}
+function typeReferenceName(type) {
+    return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+function isBuiltIn(name, use, environment) {
+    return (BUILT_INS.has(name) &&
+        !hasVisibleTypeBinding(name, use, environment.typeAliases));
+}
+function isUnappliedReferenceTo(type, name) {
+    const unwrapped = unwrapTransparentType(type);
+    return (unwrapped.type === "TSTypeReference" &&
+        typeReferenceName(unwrapped) === name &&
+        (unwrapped.typeArguments === null ||
+            unwrapped.typeArguments === undefined ||
+            unwrapped.typeArguments.params.length === 0));
+}
+function unwrapTransparentType(type) {
+    let current = type;
+    while (current.type === "TSParenthesizedType" ||
+        (current.type === "TSTypeOperator" && current.operator === "readonly")) {
+        current = current.typeAnnotation;
+    }
+    return current;
+}
+function isNeverType(type) {
+    return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+function isEffectivelyEmptyMember(member) {
+    return (member.type === "TSPropertySignature" &&
+        member.optional === true &&
+        member.typeAnnotation !== null &&
+        member.typeAnnotation !== undefined &&
+        isNeverType(member.typeAnnotation.typeAnnotation));
+}
+function isEffectivelyEmptyTypeLiteral(type) {
+    return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+function isEffectivelyEmptyInterface(declarations) {
+    if (declarations.length !== 1)
+        return false;
+    const [type] = declarations;
+    return (type !== undefined &&
+        type.extends.length === 0 &&
+        (type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember)));
+}
+function resolvedSubstitutionArgument(type, base, resolving = new Set()) {
+    const unwrapped = unwrapTransparentType(type);
+    if (unwrapped.type !== "TSTypeReference")
+        return type;
+    const name = typeReferenceName(unwrapped);
+    if (name === null || resolving.has(name))
+        return type;
+    const substitution = base.get(name);
+    if (substitution === undefined)
+        return type;
+    const nextResolving = new Set(resolving);
+    nextResolving.add(name);
+    return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+function aliasSubstitution(alias, type, base) {
+    const parameters = alias.typeParameters?.params ?? [];
+    const arguments_ = type.typeArguments?.params ?? [];
+    const next = new Map(base);
+    for (const [index, parameter] of parameters.entries()) {
+        const argument = arguments_[index] ?? parameter.default;
+        if (argument === null || argument === undefined)
+            return null;
+        next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+    }
+    return next;
+}
+function unsafeDirectValue(type, environment, substitutions, resolvingAliases) {
+    const unwrapped = unwrapTransparentType(type);
+    if (unwrapped.type === "TSUnknownKeyword")
+        return "unknown";
+    if (unwrapped.type === "TSAnyKeyword")
+        return "any";
+    if (unwrapped.type === "TSObjectKeyword")
+        return "object";
+    if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+        return "empty-object";
+    if (unwrapped.type === "TSUnionType") {
+        return unwrapped.types.some((member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null)
+            ? "union"
+            : null;
+    }
+    if (unwrapped.type === "TSIntersectionType") {
+        const unsafeMembers = unwrapped.types.map((member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases));
+        if (unsafeMembers.includes("any"))
+            return "any";
+        return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+            ? unsafeMembers[0]
+            : null;
+    }
+    if (unwrapped.type !== "TSTypeReference")
+        return null;
+    const name = typeReferenceName(unwrapped);
+    if (name === null)
+        return null;
+    if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+        const wrapped = unwrapped.typeArguments?.params[0];
+        return wrapped === undefined
+            ? null
+            : unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+    }
+    const substitution = substitutions.get(name);
+    if (substitution !== undefined) {
+        return isUnappliedReferenceTo(substitution, name)
+            ? null
+            : unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+    }
+    const interfaceDeclarations = environment.interfaces.get(name);
+    if (interfaceDeclarations !== undefined) {
+        return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+    }
+    const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+    if (alias === null || resolvingAliases.has(name))
+        return null;
+    const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+    if (nextSubstitutions === null)
+        return null;
+    const nextResolving = new Set(resolvingAliases);
+    nextResolving.add(name);
+    return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+function dictionaryValueTypes(type, environment, substitutions, resolvingAliases) {
+    const unwrapped = unwrapTransparentType(type);
+    if (unwrapped.type === "TSTypeLiteral") {
+        return unwrapped.members.flatMap((member) => member.type === "TSIndexSignature" && member.typeAnnotation !== null
+            ? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+            : []);
+    }
+    if (unwrapped.type === "TSMappedType") {
+        return unwrapped.typeAnnotation === null
+            ? []
+            : [{ type: unwrapped.typeAnnotation, substitutions }];
+    }
+    if (unwrapped.type !== "TSTypeReference")
+        return [];
+    const name = typeReferenceName(unwrapped);
+    if (name === null)
+        return [];
+    const substitution = substitutions.get(name);
+    if (substitution !== undefined) {
+        return isUnappliedReferenceTo(substitution, name)
+            ? []
+            : dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+    }
+    if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+        const wrapped = unwrapped.typeArguments?.params[0];
+        return wrapped === undefined
+            ? []
+            : dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+    }
+    if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+        const value = unwrapped.typeArguments?.params[1] ?? null;
+        return value === null ? [] : [{ type: value, substitutions }];
+    }
+    if ((name === "Pick" || name === "Omit") &&
+        isBuiltIn(name, unwrapped, environment)) {
+        const source = unwrapped.typeArguments?.params[0];
+        return source === undefined
+            ? []
+            : dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+    }
+    const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+    if (alias === null || resolvingAliases.has(name))
+        return [];
+    const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+    if (nextSubstitutions === null)
+        return [];
+    const nextResolving = new Set(resolvingAliases);
+    nextResolving.add(name);
+    return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+export function classifyUnsafeDictionaryValue(valueType, environment) {
+    const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+    return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+export function classifyUnsafeDictionary(type, environment) {
+    for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+        const unsafeValue = unsafeDirectValue(valueType.type, environment, valueType.substitutions, new Set());
+        if (unsafeValue !== null)
+            return { kind: "unsafe-dictionary", unsafeValue };
+    }
+    return null;
+}
+export function classifyWideningTarget(type, environment) {
+    const unwrapped = unwrapTransparentType(type);
+    if (unwrapped.type === "TSUnknownKeyword")
+        return { kind: "unknown" };
+    if (unwrapped.type === "TSObjectKeyword")
+        return { kind: "object" };
+    if (unwrapped.type === "TSTypeLiteral") {
+        return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+            ? { kind: "open dictionary" }
+            : unwrapped.members.length > 0
+                ? { kind: "anonymous object" }
+                : null;
+    }
+    if (unwrapped.type === "TSMappedType")
+        return { kind: "open dictionary" };
+    if (unwrapped.type !== "TSTypeReference")
+        return null;
+    const name = typeReferenceName(unwrapped);
+    if (name === null)
+        return null;
+    if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+        const wrapped = unwrapped.typeArguments?.params[0];
+        return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+    }
+    if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+        return hasBroadRecordKey(unwrapped, environment, new Map())
+            ? { kind: "open dictionary" }
+            : null;
+    }
+    const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+    if (alias === null)
+        return null;
+    if ((alias.typeParameters?.params.length ?? 0) > 0) {
+        const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+        const resolved = substitutions === null
+            ? null
+            : classifyAliasBroadTarget(alias.typeAnnotation, environment, substitutions, new Set([name]));
+        return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
+    }
+    const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+    if (substitutions === null)
+        return null;
+    const resolved = classifyAliasBroadTarget(alias.typeAnnotation, environment, substitutions, new Set([name]));
+    return resolved;
+}
+function hasBroadRecordKey(type, environment, substitutions) {
+    const key = type.typeArguments?.params[0];
+    return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+function isBroadMappedKey(type, environment, substitutions, visitedAliases = new Set()) {
+    const unwrapped = unwrapTransparentType(type);
+    if (unwrapped.type === "TSStringKeyword" ||
+        unwrapped.type === "TSNumberKeyword" ||
+        unwrapped.type === "TSSymbolKeyword") {
+        return true;
+    }
+    if (unwrapped.type === "TSUnionType") {
+        return unwrapped.types.some((member) => isBroadMappedKey(member, environment, substitutions, visitedAliases));
+    }
+    if (unwrapped.type !== "TSTypeReference")
+        return false;
+    const name = typeReferenceName(unwrapped);
+    if (name === null)
+        return false;
+    const substitution = substitutions.get(name);
+    if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+        return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
+    }
+    if (name === "PropertyKey" && isBuiltIn(name, unwrapped, environment))
+        return true;
+    const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+    if (alias === null ||
+        (alias.typeParameters?.params.length ?? 0) > 0 ||
+        visitedAliases.has(name)) {
+        return false;
+    }
+    const nextVisited = new Set(visitedAliases);
+    nextVisited.add(name);
+    return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
+}
+function classifyAliasBroadTarget(type, environment, substitutions, resolvingAliases) {
+    const unwrapped = unwrapTransparentType(type);
+    if (unwrapped.type === "TSUnknownKeyword")
+        return { kind: "unknown" };
+    if (unwrapped.type === "TSObjectKeyword")
+        return { kind: "object" };
+    if (unwrapped.type === "TSTypeLiteral") {
+        return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+            ? { kind: "open dictionary" }
+            : null;
+    }
+    if (unwrapped.type === "TSMappedType") {
+        return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+            ? { kind: "open dictionary" }
+            : null;
+    }
+    if (unwrapped.type !== "TSTypeReference")
+        return null;
+    const name = typeReferenceName(unwrapped);
+    if (name === null)
+        return null;
+    const substitution = substitutions.get(name);
+    if (substitution !== undefined) {
+        return isUnappliedReferenceTo(substitution, name)
+            ? null
+            : classifyAliasBroadTarget(substitution, environment, substitutions, resolvingAliases);
+    }
+    if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+        const wrapped = unwrapped.typeArguments?.params[0];
+        return wrapped === undefined
+            ? null
+            : classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+    }
+    if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+        return hasBroadRecordKey(unwrapped, environment, substitutions)
+            ? { kind: "open dictionary" }
+            : null;
+    }
+    const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+    if (alias === null || resolvingAliases.has(name))
+        return null;
+    const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+    if (nextSubstitutions === null)
+        return null;
+    const nextResolving = new Set(resolvingAliases);
+    nextResolving.add(name);
+    return classifyAliasBroadTarget(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+export function isPopulatedObjectExpression(expression) {
+    let current = expression;
+    while (current.type === "ParenthesizedExpression" ||
+        current.type === "TSAsExpression" ||
+        current.type === "TSTypeAssertion" ||
+        current.type === "TSNonNullExpression") {
+        current = current.expression;
+    }
+    return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+export function isKnownEvidenceExpression(expression) {
+    let current = expression;
+    while (current.type === "ParenthesizedExpression" ||
+        current.type === "TSAsExpression" ||
+        current.type === "TSTypeAssertion" ||
+        current.type === "TSNonNullExpression" ||
+        current.type === "TSSatisfiesExpression") {
+        current = current.expression;
+    }
+    if (current.type === "ObjectExpression")
+        return true;
+    return (current.type === "ArrayExpression" ||
+        current.type === "ArrowFunctionExpression" ||
+        current.type === "ClassExpression" ||
+        current.type === "FunctionExpression" ||
+        current.type === "NewExpression" ||
+        current.type === "Literal" ||
+        current.type === "TemplateLiteral" ||
+        current.type === "UnaryExpression");
+}

--- a/dist/shared/function-parameters.d.ts
+++ b/dist/shared/function-parameters.d.ts
@@ -1,0 +1,8 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+export type FunctionParameter = ESTree.ParamPattern;
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export declare function containsUnknownType(type: ESTree.TSType): boolean;
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export declare function functionParameterTypeAnnotation(parameter: FunctionParameter): ESTree.TSTypeAnnotation | null | undefined;
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export declare function functionParameterBindingName(parameter: FunctionParameter, sourceCode: SourceCode): string;

--- a/dist/shared/function-parameters.js
+++ b/dist/shared/function-parameters.js
@@ -1,0 +1,40 @@
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export function containsUnknownType(type) {
+    if (type.type === "TSUnknownKeyword")
+        return true;
+    if (type.type === "TSParenthesizedType")
+        return containsUnknownType(type.typeAnnotation);
+    return type.type === "TSUnionType" && type.types.some(containsUnknownType);
+}
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export function functionParameterTypeAnnotation(parameter) {
+    if (parameter.type === "TSParameterProperty") {
+        return functionParameterTypeAnnotation(parameter.parameter);
+    }
+    if (parameter.type === "RestElement") {
+        return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.argument);
+    }
+    if (parameter.type === "AssignmentPattern") {
+        return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.left);
+    }
+    return parameter.typeAnnotation;
+}
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export function functionParameterBindingName(parameter, sourceCode) {
+    if (parameter.type === "TSParameterProperty") {
+        return functionParameterBindingName(parameter.parameter, sourceCode);
+    }
+    if (parameter.type === "AssignmentPattern") {
+        return functionParameterBindingName(parameter.left, sourceCode);
+    }
+    if (parameter.type === "RestElement") {
+        return functionParameterBindingName(parameter.argument, sourceCode);
+    }
+    if (parameter.type === "Identifier")
+        return parameter.name;
+    const sourceText = sourceCode.getText(parameter);
+    const annotationStart = parameter.typeAnnotation?.start;
+    return annotationStart === undefined
+        ? sourceText
+        : sourceText.slice(0, annotationStart - parameter.start).trimEnd();
+}

--- a/dist/shared/lexical-type-parameters.d.ts
+++ b/dist/shared/lexical-type-parameters.d.ts
@@ -1,0 +1,5 @@
+import type { ESTree } from "@oxlint/plugins";
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export declare function lexicalTypeParameterNames(node: ESTree.Node, visitorKeys: VisitorKeys): ReadonlySet<string>;
+export {};

--- a/dist/shared/lexical-type-parameters.js
+++ b/dist/shared/lexical-type-parameters.js
@@ -1,0 +1,47 @@
+function isNode(value) {
+    return (typeof value === "object" &&
+        value !== null &&
+        "type" in value &&
+        typeof value.type === "string");
+}
+function collectInferTypeParameterNames(node, visitorKeys, names) {
+    if (node.type === "TSInferType")
+        names.add(node.typeParameter.name.name);
+    const record = node;
+    for (const key of visitorKeys[node.type] ?? []) {
+        const value = record[key];
+        if (isNode(value)) {
+            collectInferTypeParameterNames(value, visitorKeys, names);
+            continue;
+        }
+        if (!Array.isArray(value))
+            continue;
+        for (const child of value) {
+            if (isNode(child))
+                collectInferTypeParameterNames(child, visitorKeys, names);
+        }
+    }
+}
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(node, visitorKeys) {
+    const names = new Set();
+    let descendant = node;
+    let current = node;
+    while (current !== null && current.type !== "Program") {
+        if ("typeParameters" in current) {
+            for (const parameter of current.typeParameters?.params ?? []) {
+                names.add(parameter.name.name);
+            }
+        }
+        if (current.type === "TSMappedType" &&
+            (descendant === current.nameType || descendant === current.typeAnnotation)) {
+            names.add(current.key.name);
+        }
+        if (current.type === "TSConditionalType" && descendant === current.trueType) {
+            collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+        }
+        descendant = current;
+        current = current.parent;
+    }
+    return names;
+}

--- a/dist/shared/reflect-method.d.ts
+++ b/dist/shared/reflect-method.d.ts
@@ -1,0 +1,3 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+/** Reports whether a call target names one method on the global Reflect object. */
+export declare function isGlobalReflectMethodCall(sourceCode: SourceCode, callee: ESTree.Expression, methodName: string): boolean;

--- a/dist/shared/reflect-method.js
+++ b/dist/shared/reflect-method.js
@@ -1,0 +1,29 @@
+function resolveVariable(sourceCode, identifier) {
+    let scope = sourceCode.getScope(identifier);
+    while (scope !== null) {
+        const variable = scope.set.get(identifier.name);
+        if (variable !== undefined)
+            return variable;
+        scope = scope.upper;
+    }
+    return null;
+}
+function isGlobalReflect(sourceCode, expression) {
+    if (expression.type !== "Identifier" || expression.name !== "Reflect")
+        return false;
+    if (sourceCode.isGlobalReference(expression))
+        return true;
+    const variable = resolveVariable(sourceCode, expression);
+    return variable === null || variable.defs.length === 0;
+}
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(sourceCode, callee, methodName) {
+    if (!("property" in callee) || !("object" in callee) || !("computed" in callee))
+        return false;
+    if (!isGlobalReflect(sourceCode, callee.object))
+        return false;
+    const property = callee.property;
+    return callee.computed
+        ? property.type === "Literal" && property.value === methodName
+        : property.type === "Identifier" && property.name === methodName;
+}

--- a/dist/shared/type-alias-resolution.d.ts
+++ b/dist/shared/type-alias-resolution.d.ts
@@ -1,0 +1,23 @@
+import type { ESTree } from "@oxlint/plugins";
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+type TypeScope = ESTree.Node;
+type TypeBinding = {
+    readonly alias: ESTree.TSTypeAliasDeclaration | null;
+    readonly name: string;
+    readonly scope: TypeScope;
+};
+export type TypeAliasEnvironment = {
+    readonly aliases: readonly ESTree.TSTypeAliasDeclaration[];
+    readonly bindingsByName: ReadonlyMap<string, readonly TypeBinding[]>;
+    readonly visitorKeys: VisitorKeys;
+};
+export type ResolvedTypeMatcher = (type: ESTree.TSType, matches: (child: ESTree.TSType) => boolean) => boolean;
+/** Collect every lexical type alias and competing type binding in a program. */
+export declare function createTypeAliasEnvironment(program: ESTree.Program, visitorKeys: VisitorKeys): TypeAliasEnvironment;
+/** Resolve the nearest visible alias with this name, respecting lexical shadowing. */
+export declare function visibleTypeAlias(name: string, use: ESTree.Node, environment: TypeAliasEnvironment): ESTree.TSTypeAliasDeclaration | null;
+/** Return whether a local declaration shadows a built-in type at this use. */
+export declare function hasVisibleTypeBinding(name: string, use: ESTree.Node, environment: TypeAliasEnvironment): boolean;
+/** Match a type after resolving visible aliases and substituting their type parameters. */
+export declare function resolvedTypeMatches(type: ESTree.TSType, environment: TypeAliasEnvironment, matcher: ResolvedTypeMatcher): boolean;
+export {};

--- a/dist/shared/type-alias-resolution.js
+++ b/dist/shared/type-alias-resolution.js
@@ -1,0 +1,162 @@
+import { lexicalTypeParameterNames } from "./lexical-type-parameters.js";
+const environmentsByProgram = new WeakMap();
+function isNode(value) {
+    return (typeof value === "object" &&
+        value !== null &&
+        "type" in value &&
+        typeof value.type === "string");
+}
+function enclosingTypeScope(node) {
+    let current = node.parent;
+    while (current !== null) {
+        if (current.type === "Program" ||
+            current.type === "BlockStatement" ||
+            current.type === "TSModuleBlock" ||
+            current.type === "StaticBlock" ||
+            current.type === "SwitchStatement") {
+            return current;
+        }
+        current = current.parent;
+    }
+    return node;
+}
+function declaredTypeBinding(node) {
+    if (node.type === "TSTypeAliasDeclaration") {
+        return { alias: node, name: node.id.name };
+    }
+    if (node.type === "TSInterfaceDeclaration" ||
+        node.type === "TSEnumDeclaration" ||
+        node.type === "ClassDeclaration" ||
+        node.type === "ClassExpression") {
+        return node.id === null ? null : { alias: null, name: node.id.name };
+    }
+    if (node.type === "ImportSpecifier" ||
+        node.type === "ImportDefaultSpecifier" ||
+        node.type === "ImportNamespaceSpecifier") {
+        return { alias: null, name: node.local.name };
+    }
+    return null;
+}
+function collectTypeBindings(node, visitorKeys, bindingsByName, aliases) {
+    const declared = declaredTypeBinding(node);
+    if (declared !== null) {
+        const bindings = bindingsByName.get(declared.name) ?? [];
+        bindings.push({ ...declared, scope: enclosingTypeScope(node) });
+        bindingsByName.set(declared.name, bindings);
+        if (declared.alias !== null)
+            aliases.push(declared.alias);
+    }
+    // SAFETY: Oxlint's visitor keys identify only ESTree child-node properties.
+    const fields = node;
+    for (const key of visitorKeys[node.type] ?? []) {
+        const value = fields[key];
+        if (isNode(value)) {
+            collectTypeBindings(value, visitorKeys, bindingsByName, aliases);
+            continue;
+        }
+        if (!Array.isArray(value))
+            continue;
+        for (const child of value) {
+            if (isNode(child)) {
+                collectTypeBindings(child, visitorKeys, bindingsByName, aliases);
+            }
+        }
+    }
+}
+/** Collect every lexical type alias and competing type binding in a program. */
+export function createTypeAliasEnvironment(program, visitorKeys) {
+    const cached = environmentsByProgram.get(program);
+    if (cached !== undefined)
+        return cached;
+    const bindingsByName = new Map();
+    const aliases = [];
+    collectTypeBindings(program, visitorKeys, bindingsByName, aliases);
+    const environment = { aliases, bindingsByName, visitorKeys };
+    environmentsByProgram.set(program, environment);
+    return environment;
+}
+function ancestorDistance(ancestor, node) {
+    let current = node;
+    let distance = 0;
+    while (current !== null) {
+        if (current === ancestor)
+            return distance;
+        current = current.parent;
+        distance += 1;
+    }
+    return null;
+}
+function nearestTypeBindings(name, use, environment) {
+    const candidates = environment.bindingsByName.get(name) ?? [];
+    let nearestDistance = Number.POSITIVE_INFINITY;
+    let nearest = [];
+    for (const candidate of candidates) {
+        const distance = ancestorDistance(candidate.scope, use);
+        if (distance === null || distance > nearestDistance)
+            continue;
+        if (distance === nearestDistance) {
+            nearest.push(candidate);
+            continue;
+        }
+        nearestDistance = distance;
+        nearest = [candidate];
+    }
+    return nearest;
+}
+/** Resolve the nearest visible alias with this name, respecting lexical shadowing. */
+export function visibleTypeAlias(name, use, environment) {
+    if (lexicalTypeParameterNames(use, environment.visitorKeys).has(name))
+        return null;
+    const bindings = nearestTypeBindings(name, use, environment);
+    return bindings.length === 1 ? (bindings[0]?.alias ?? null) : null;
+}
+/** Return whether a local declaration shadows a built-in type at this use. */
+export function hasVisibleTypeBinding(name, use, environment) {
+    return (lexicalTypeParameterNames(use, environment.visitorKeys).has(name) ||
+        nearestTypeBindings(name, use, environment).length > 0);
+}
+function typeReferenceName(type) {
+    return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+function aliasSubstitutions(alias, reference, base) {
+    const parameters = alias.typeParameters?.params ?? [];
+    const arguments_ = reference.typeArguments?.params ?? [];
+    const next = new Map(base);
+    for (const [index, parameter] of parameters.entries()) {
+        const explicitArgument = arguments_[index];
+        const argument = explicitArgument ?? parameter.default;
+        if (argument === null || argument === undefined)
+            return null;
+        const argumentSubstitutions = explicitArgument === undefined ? next : base;
+        next.set(parameter.name.name, {
+            type: argument,
+            substitutions: new Map(argumentSubstitutions),
+        });
+    }
+    return next;
+}
+/** Match a type after resolving visible aliases and substituting their type parameters. */
+export function resolvedTypeMatches(type, environment, matcher) {
+    const evaluate = (current, substitutions, resolvingAliases) => {
+        if (current.type === "TSTypeReference") {
+            const name = typeReferenceName(current);
+            if (name !== null) {
+                const substitution = substitutions.get(name);
+                if (substitution !== undefined && !current.typeArguments?.params.length) {
+                    return evaluate(substitution.type, substitution.substitutions, resolvingAliases);
+                }
+                const alias = visibleTypeAlias(name, current, environment);
+                if (alias !== null && !resolvingAliases.has(alias)) {
+                    const nextSubstitutions = aliasSubstitutions(alias, current, substitutions);
+                    if (nextSubstitutions !== null) {
+                        const nextResolving = new Set(resolvingAliases);
+                        nextResolving.add(alias);
+                        return evaluate(alias.typeAnnotation, nextSubstitutions, nextResolving);
+                    }
+                }
+            }
+        }
+        return matcher(current, (child) => evaluate(child, substitutions, resolvingAliases));
+    };
+    return evaluate(type, new Map(), new Set());
+}

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "check:skill-assets": "node scripts/sync-skill-assets.mjs --check"
   },
   "dependencies": {
-    "@oxlint/plugins": "1.78.0"
+    "@oxlint/plugins": "1.73.0"
   },
   "devDependencies": {
     "@types/node": "26.2.0",
-    "oxlint": "1.78.0",
+    "oxlint": "1.73.0",
     "tsx": "4.23.12",
     "typescript": "7.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -4,12 +4,22 @@
   "private": true,
   "description": "Opinionated Oxlint rules that reject low-evidence TypeScript and JavaScript patterns.",
   "type": "module",
-  "exports": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./effect": {
+      "types": "./dist/effect/index.d.ts",
+      "default": "./dist/effect/index.js"
+    }
+  },
   "files": [
-    "src"
+    "dist"
   ],
   "scripts": {
-    "check": "pnpm lint && pnpm test && pnpm typecheck && pnpm check:skill-assets",
+    "build": "tsc -p tsconfig.build.json",
+    "check": "pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm check:skill-assets",
     "lint": "oxlint src",
     "test": "tsx src/rules/no-chained-type-assertions.test.ts && tsx src/rules/no-conditional-empty-object-spread.test.ts && tsx src/rules/no-unsafe-dictionary-type.test.ts && tsx src/rules/no-known-value-widening.test.ts && tsx src/rules/no-object-parameters.test.ts && tsx src/rules/no-unknown-parameters.test.ts && tsx src/rules/no-runtime-typeof.test.ts && tsx src/rules/no-shape-in-symbol-names.test.ts && tsx src/rules/no-unknown-returns.test.ts && tsx src/rules/no-unknown-type-aliases.test.ts && tsx src/rules/no-widen-then-assert.test.ts && tsx src/rules/no-reflect-get.test.ts && tsx src/rules/no-reflect-apply.test.ts && tsx src/rules/no-module-mocking.test.ts && tsx src/rules/require-safety-comment-for-type-assertion.test.ts && tsx src/effect/rules/no-service-constructor-imports.test.ts",
     "typecheck": "tsc --noEmit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,15 +9,15 @@ importers:
   .:
     dependencies:
       '@oxlint/plugins':
-        specifier: 1.78.0
-        version: 1.78.0
+        specifier: 1.73.0
+        version: 1.73.0
     devDependencies:
       '@types/node':
         specifier: 26.2.0
         version: 26.2.0
       oxlint:
-        specifier: 1.78.0
-        version: 1.78.0
+        specifier: 1.73.0
+        version: 1.73.0
       tsx:
         specifier: 4.23.12
         version: 4.23.12
@@ -183,130 +183,130 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.78.0':
-    resolution: {integrity: sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw==}
+  '@oxlint/binding-android-arm-eabi@1.73.0':
+    resolution: {integrity: sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.78.0':
-    resolution: {integrity: sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ==}
+  '@oxlint/binding-android-arm64@1.73.0':
+    resolution: {integrity: sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.78.0':
-    resolution: {integrity: sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA==}
+  '@oxlint/binding-darwin-arm64@1.73.0':
+    resolution: {integrity: sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.78.0':
-    resolution: {integrity: sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g==}
+  '@oxlint/binding-darwin-x64@1.73.0':
+    resolution: {integrity: sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.78.0':
-    resolution: {integrity: sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg==}
+  '@oxlint/binding-freebsd-x64@1.73.0':
+    resolution: {integrity: sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.78.0':
-    resolution: {integrity: sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.73.0':
+    resolution: {integrity: sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.78.0':
-    resolution: {integrity: sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.73.0':
+    resolution: {integrity: sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.78.0':
-    resolution: {integrity: sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg==}
+  '@oxlint/binding-linux-arm64-gnu@1.73.0':
+    resolution: {integrity: sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.78.0':
-    resolution: {integrity: sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg==}
+  '@oxlint/binding-linux-arm64-musl@1.73.0':
+    resolution: {integrity: sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.78.0':
-    resolution: {integrity: sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ==}
+  '@oxlint/binding-linux-ppc64-gnu@1.73.0':
+    resolution: {integrity: sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.78.0':
-    resolution: {integrity: sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA==}
+  '@oxlint/binding-linux-riscv64-gnu@1.73.0':
+    resolution: {integrity: sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.78.0':
-    resolution: {integrity: sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg==}
+  '@oxlint/binding-linux-riscv64-musl@1.73.0':
+    resolution: {integrity: sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.78.0':
-    resolution: {integrity: sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw==}
+  '@oxlint/binding-linux-s390x-gnu@1.73.0':
+    resolution: {integrity: sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.78.0':
-    resolution: {integrity: sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ==}
+  '@oxlint/binding-linux-x64-gnu@1.73.0':
+    resolution: {integrity: sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.78.0':
-    resolution: {integrity: sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg==}
+  '@oxlint/binding-linux-x64-musl@1.73.0':
+    resolution: {integrity: sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.78.0':
-    resolution: {integrity: sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg==}
+  '@oxlint/binding-openharmony-arm64@1.73.0':
+    resolution: {integrity: sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.78.0':
-    resolution: {integrity: sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA==}
+  '@oxlint/binding-win32-arm64-msvc@1.73.0':
+    resolution: {integrity: sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.78.0':
-    resolution: {integrity: sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA==}
+  '@oxlint/binding-win32-ia32-msvc@1.73.0':
+    resolution: {integrity: sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.78.0':
-    resolution: {integrity: sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA==}
+  '@oxlint/binding-win32-x64-msvc@1.73.0':
+    resolution: {integrity: sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/plugins@1.78.0':
-    resolution: {integrity: sha512-Ypt8KeRYw+4jUtlPirfcHWMrn5ms12VrrFPD+Mds477/7tJxG1Kcz2Yrg2nVcTQEUx/GdlhS+BUg1kmxNm04Ug==}
+  '@oxlint/plugins@1.73.0':
+    resolution: {integrity: sha512-OhgMQeMmZA0dcFcX4/priaJZWdFECxiClgq6mRX6aatZEcV9PbKC3P3/v8U1hVjviT1i5U+vR8lAtBV6m4FXAA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@types/node@26.2.0':
@@ -442,12 +442,12 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  oxlint@1.78.0:
-    resolution: {integrity: sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA==}
+  oxlint@1.73.0:
+    resolution: {integrity: sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=7.0.2001'
+      oxlint-tsgolint: '>=0.24.0'
       vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
@@ -548,64 +548,64 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.78.0':
+  '@oxlint/binding-android-arm-eabi@1.73.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.78.0':
+  '@oxlint/binding-android-arm64@1.73.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.78.0':
+  '@oxlint/binding-darwin-arm64@1.73.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.78.0':
+  '@oxlint/binding-darwin-x64@1.73.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.78.0':
+  '@oxlint/binding-freebsd-x64@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.78.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.78.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.78.0':
+  '@oxlint/binding-linux-arm64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.78.0':
+  '@oxlint/binding-linux-arm64-musl@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.78.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.78.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.78.0':
+  '@oxlint/binding-linux-riscv64-musl@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.78.0':
+  '@oxlint/binding-linux-s390x-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.78.0':
+  '@oxlint/binding-linux-x64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.78.0':
+  '@oxlint/binding-linux-x64-musl@1.73.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.78.0':
+  '@oxlint/binding-openharmony-arm64@1.73.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.78.0':
+  '@oxlint/binding-win32-arm64-msvc@1.73.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.78.0':
+  '@oxlint/binding-win32-ia32-msvc@1.73.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.78.0':
+  '@oxlint/binding-win32-x64-msvc@1.73.0':
     optional: true
 
-  '@oxlint/plugins@1.78.0': {}
+  '@oxlint/plugins@1.73.0': {}
 
   '@types/node@26.2.0':
     dependencies:
@@ -703,27 +703,27 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  oxlint@1.78.0:
+  oxlint@1.73.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.78.0
-      '@oxlint/binding-android-arm64': 1.78.0
-      '@oxlint/binding-darwin-arm64': 1.78.0
-      '@oxlint/binding-darwin-x64': 1.78.0
-      '@oxlint/binding-freebsd-x64': 1.78.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.78.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.78.0
-      '@oxlint/binding-linux-arm64-gnu': 1.78.0
-      '@oxlint/binding-linux-arm64-musl': 1.78.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.78.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.78.0
-      '@oxlint/binding-linux-riscv64-musl': 1.78.0
-      '@oxlint/binding-linux-s390x-gnu': 1.78.0
-      '@oxlint/binding-linux-x64-gnu': 1.78.0
-      '@oxlint/binding-linux-x64-musl': 1.78.0
-      '@oxlint/binding-openharmony-arm64': 1.78.0
-      '@oxlint/binding-win32-arm64-msvc': 1.78.0
-      '@oxlint/binding-win32-ia32-msvc': 1.78.0
-      '@oxlint/binding-win32-x64-msvc': 1.78.0
+      '@oxlint/binding-android-arm-eabi': 1.73.0
+      '@oxlint/binding-android-arm64': 1.73.0
+      '@oxlint/binding-darwin-arm64': 1.73.0
+      '@oxlint/binding-darwin-x64': 1.73.0
+      '@oxlint/binding-freebsd-x64': 1.73.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.73.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.73.0
+      '@oxlint/binding-linux-arm64-gnu': 1.73.0
+      '@oxlint/binding-linux-arm64-musl': 1.73.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.73.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.73.0
+      '@oxlint/binding-linux-riscv64-musl': 1.73.0
+      '@oxlint/binding-linux-s390x-gnu': 1.73.0
+      '@oxlint/binding-linux-x64-gnu': 1.73.0
+      '@oxlint/binding-linux-x64-musl': 1.73.0
+      '@oxlint/binding-openharmony-arm64': 1.73.0
+      '@oxlint/binding-win32-arm64-msvc': 1.73.0
+      '@oxlint/binding-win32-ia32-msvc': 1.73.0
+      '@oxlint/binding-win32-x64-msvc': 1.73.0
 
   tsx@4.23.12:
     dependencies:

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-module-mocking.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-module-mocking.ts
@@ -75,7 +75,7 @@ export const noModuleMockingRule = defineRule({
     },
     messages: {
       moduleMock:
-        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+        "Replace module mocking with dependency injection through a real seam. If this test covers a composition root, module imports are the dependency graph under test; document that boundary and disable this rule for the file with `/* oxlint-disable anti-slop/no-module-mocking */`.",
     },
   },
   createOnce(context) {

--- a/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-parameters.ts
+++ b/skills/install-anti-slop/assets/anti-slop/rules/no-unknown-parameters.ts
@@ -6,6 +6,9 @@ import {
   functionParameterBindingName,
   functionParameterTypeAnnotation,
 } from "../shared/function-parameters.ts";
+
+// Allows conventional names only at explicit error-handling boundaries.
+const unknownErrorParameterNames = new Set(["cause", "error", "reason"]);
 type ParameterOwner =
   | ESTree.ArrowFunctionExpression
   | ESTree.Function
@@ -24,13 +27,13 @@ function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): b
   );
 }
 
-/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+/** Disallow unknown inputs except explicitly named error handling and type predicates. */
 export const noUnknownParametersRule = defineRule({
   meta: {
     type: "problem",
     docs: {
       description:
-        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
+        "Disallow explicitly unknown function parameters except conventional error parameters and type-predicate subjects; decode unknown input at its I/O boundary instead.",
     },
     messages: {
       unknownParameter:
@@ -44,7 +47,7 @@ export const noUnknownParametersRule = defineRule({
         if (annotation === null || annotation === undefined) continue;
         if (!containsUnknownType(annotation.typeAnnotation)) continue;
         const name = functionParameterBindingName(parameter, context.sourceCode);
-        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
+        if (unknownErrorParameterNames.has(name) || isTypePredicateSubject(node, name)) continue;
         context.report({
           node: annotation.typeAnnotation,
           messageId: "unknownParameter",

--- a/src/rules/no-module-mocking.ts
+++ b/src/rules/no-module-mocking.ts
@@ -75,7 +75,7 @@ export const noModuleMockingRule = defineRule({
     },
     messages: {
       moduleMock:
-        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+        "Replace module mocking with dependency injection through a real seam. If this test covers a composition root, module imports are the dependency graph under test; document that boundary and disable this rule for the file with `/* oxlint-disable anti-slop/no-module-mocking */`.",
     },
   },
   createOnce(context) {

--- a/src/rules/no-unknown-parameters.test.ts
+++ b/src/rules/no-unknown-parameters.test.ts
@@ -9,6 +9,8 @@ tester.run("anti-slop/no-unknown-parameters", noUnknownParametersRule, {
 	valid: [
 		"function enrich(cause: unknown): void {}",
 		"function enrich(cause: Error | unknown): void {}",
+		"function normalize(error: unknown): Error { return new Error(String(error)); }",
+		"function reject(reason: Error | unknown): void {}",
 		"function isString(value: unknown): value is string { return true; }",
 		"const isString = (value: unknown): value is string => true;",
 		"function assertString(value: unknown): asserts value is string {}",

--- a/src/rules/no-unknown-parameters.ts
+++ b/src/rules/no-unknown-parameters.ts
@@ -6,6 +6,9 @@ import {
   functionParameterBindingName,
   functionParameterTypeAnnotation,
 } from "../shared/function-parameters.ts";
+
+// Allows conventional names only at explicit error-handling boundaries.
+const unknownErrorParameterNames = new Set(["cause", "error", "reason"]);
 type ParameterOwner =
   | ESTree.ArrowFunctionExpression
   | ESTree.Function
@@ -24,13 +27,13 @@ function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): b
   );
 }
 
-/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+/** Disallow unknown inputs except explicitly named error handling and type predicates. */
 export const noUnknownParametersRule = defineRule({
   meta: {
     type: "problem",
     docs: {
       description:
-        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
+        "Disallow explicitly unknown function parameters except conventional error parameters and type-predicate subjects; decode unknown input at its I/O boundary instead.",
     },
     messages: {
       unknownParameter:
@@ -44,7 +47,7 @@ export const noUnknownParametersRule = defineRule({
         if (annotation === null || annotation === undefined) continue;
         if (!containsUnknownType(annotation.typeAnnotation)) continue;
         const name = functionParameterBindingName(parameter, context.sourceCode);
-        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
+        if (unknownErrorParameterNames.has(name) || isTypePredicateSubject(node, name)) continue;
         context.report({
           node: annotation.typeAnnotation,
           messageId: "unknownParameter",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true,
+    "rootDir": "src"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- allow conventional `cause`, `error`, and `reason` names for unknown error-boundary parameters
- explain the documented composition-root exception in the module-mocking diagnostic
- align Oxlint and `@oxlint/plugins` at 1.73.0 for the current consumers
- emit and export compiled JavaScript so Git dependencies load from `node_modules`
- keep install-skill assets synchronized with canonical source

## Verification

- `pnpm check` — passed
- Oxlint source lint — passed
- all 16 rule test commands — passed
- TypeScript typecheck — passed
- JavaScript distribution build — passed
- install-skill asset consistency — passed

The Polymonkey backend and frontend both load the plugin successfully from commit `b9f664aa7f70aff1eea10fbb90a3370fd27019f6`.
